### PR TITLE
test: update flag in test

### DIFF
--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -140,7 +140,7 @@ childProcess.exec(nodeBinary + ' '
 // https://github.com/nodejs/node/issues/1691
 process.chdir(common.fixturesDir);
 childProcess.exec(nodeBinary + ' '
-  + '--expose_debug_as=v8debug '
+  + '--expose_natives_as=v8natives '
   + '--require ' + fixture('cluster-preload.js') + ' '
   + 'cluster-preload-test.js',
   function(err, stdout, stderr) {


### PR DESCRIPTION
Previously used flag is deprecated in V8, use a flag
that still exists.

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->
Previously used flag is deprecated in V8, use a flag that still exists.

