### PR TITLE
src: remove usage of deprecated debug API

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -244,6 +244,9 @@ class ContextifyContext {
   }
 
 
+  static void DummyDebugEventListener(const Debug::EventDetails&) {}
+
+
   static void RunInDebugContext(const FunctionCallbackInfo<Value>& args) {
     Local<String> script_source(args[0]->ToString(args.GetIsolate()));
     if (script_source.IsEmpty())
@@ -252,7 +255,7 @@ class ContextifyContext {
     Environment* env = Environment::GetCurrent(args);
     if (debug_context.IsEmpty()) {
       // Force-load the debug context.
-      Debug::GetMirror(args.GetIsolate()->GetCurrentContext(), args[0]);
+      Debug::SetDebugEventListener(args.GetIsolate(), DummyDebugEventListener);
       debug_context = Debug::GetDebugContext(args.GetIsolate());
       CHECK(!debug_context.IsEmpty());
       // Ensure that the debug context has an Environment assigned in case


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
contextify

##### Description of change
Debug::GetMirror is used here to force loading of the debug context.
There is a better way to achieve this: by adding a debug event listener,
the debugger is enabled and the debug context is loaded

