### PR TITLE
process: use rest parameters in nextTick.

### DIFF
--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -73,6 +73,9 @@ function setupNextTick() {
       callback();
     } else {
       switch (args.length) {
+        case 0:
+          callback();
+          break;
         case 1:
           callback(args[0]);
           break;
@@ -137,19 +140,12 @@ function setupNextTick() {
     } while (tickInfo[kLength] !== 0);
   }
 
-  function nextTick(callback) {
+  function nextTick(callback, ...args) {
     if (typeof callback !== 'function')
       throw new TypeError('callback is not a function');
     // on the way out, don't bother. it won't get fired anyway.
     if (process._exiting)
       return;
-
-    var args;
-    if (arguments.length > 1) {
-      args = new Array(arguments.length - 1);
-      for (var i = 1; i < arguments.length; i++)
-        args[i - 1] = arguments[i];
-    }
 
     nextTickQueue.push({
       callback,


### PR DESCRIPTION
This increases the performance of `stream/writeable-manywrites.js`
both with Crankshaft and with Turbofan significantly, improving the score from ~1,700,000 to ~2,400,000.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)

- process
