### PR TITLE
lib: spread arguments in tick callbacks

### DIFF
--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -86,7 +86,7 @@ function setupNextTick() {
           callback(args[0], args[1], args[2]);
           break;
         default:
-          callback.apply(null, args);
+          callback(...args);
       }
     }
   }


### PR DESCRIPTION
This is performance neutral and removes Crankshaft-specific
code anti-patterns.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)

- lib
