### PR TITLE
[test]: Fix test and update status file

### DIFF
--- a/test/message/message.status
+++ b/test/message/message.status
@@ -5,6 +5,7 @@ prefix message
 # sample-test                       : PASS,FLAKY
 
 [true] # This section applies to all platforms
+unhandled_promise_trace_warnings : FAIL
 
 [$system==win32]
 

--- a/test/message/unhandled_promise_trace_warnings.out
+++ b/test/message/unhandled_promise_trace_warnings.out
@@ -21,7 +21,6 @@
     at getAsynchronousRejectionWarningObject (internal/process/promises.js:*)
     at rejectionHandled (internal/process/promises.js:*)
     at *
-    at Promise.then *
     at Promise.catch *
     at Immediate.setImmediate [as _onImmediate] (*test*message*unhandled_promise_trace_warnings.js:*)
     at *


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

I've been moving the [hash code](https://docs.google.com/document/d/1qsmgnqXRLa0-vCwdKcgXreCsn9PpajdDjHxx1G25RBY/edit) to not be stored as a private symbol. As a result of this, when we add an object to a WeakMap, we no longer cause a map transition (which was previously caused by the private symbol addition).

Node [stores promise objects in WeakMaps](https://github.com/v8/node/blob/vee-eight-lkgr/lib/internal/process/promises.js) for printing the unhandled rejection error. This previously caused a map transition on the promise object, making it different from the unmodified promise map that we store on the native context (which we use internally in V8 for fast paths).

I added a [fast path in Promise.prototype.catch](https://github.com/v8/v8/blob/master/src/builtins/builtins-promise-gen.cc#L1359) that does a map check on the receiver against the unmodified promise map that was stored on the native context. When the map check passed, we would directly call the internal `Promise.prototype.then` because it does not have side effects for native unmodified promises. But, when the map check failed, we had to look up the `then` property on the receiver and call into it. This makes `Promise.then` show up on the stack trace.

After https://chromium-review.googlesource.com/c/589688 (which completely removes this hash code private symbol), adding the promise object to the WeakMap in node, no longer causes a map transition on the promise object. This means that the fast path map check always passes in `Promise.prototype.catch`, and we don't see the `Promise.then` call on the stacktrace.

Note: This CL also probably improves promise performance for certain cases in node because we no longer fall of the fast path.

This patch updates the test to no longer have this `Promise.then` call in the stacktrace. This causes the test to fail without my patch, so I've updated the status file as well. The status file has to be updated once again after my CL has landed.