### PR TITLE
[HACK] Implement new v8::Platform method.

### DIFF
--- a/deps/v8/src/v8.gyp
+++ b/deps/v8/src/v8.gyp
@@ -2211,6 +2211,7 @@
       'direct_dependent_settings': {
         'include_dirs': [
           '../include',
+          '..',    # Hack to reuse V8's implementation of time.
         ],
       },
     },

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -1,6 +1,7 @@
 #include "node_platform.h"
 
 #include "util.h"
+#include "src/base/platform/platform.h"
 
 namespace node {
 
@@ -119,6 +120,10 @@ bool NodePlatform::IdleTasksEnabled(Isolate* isolate) { return false; }
 double NodePlatform::MonotonicallyIncreasingTime() {
   // Convert nanos to seconds.
   return uv_hrtime() / 1e9;
+}
+
+double NodePlatform::CurrentClockTimeMillis() {
+  return v8::base::OS::TimeCurrentMillis();
 }
 
 TracingController* NodePlatform::GetTracingController() {

--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -51,6 +51,7 @@ class NodePlatform : public v8::Platform {
                                      double delay_in_seconds) override;
   bool IdleTasksEnabled(v8::Isolate* isolate) override;
   double MonotonicallyIncreasingTime() override;
+  double CurrentClockTimeMillis() override;
   v8::TracingController* GetTracingController() override;
 
  private:


### PR DESCRIPTION
With the upcoming https://chromium-review.googlesource.com/c/v8/v8/+/598666 implementation of current time method is required. Workaround the problem for now.