### PR TITLE
Disable one UTF-8 test.

### DIFF
--- a/test/parallel/test-string-decoder.js
+++ b/test/parallel/test-string-decoder.js
@@ -69,7 +69,13 @@ test('utf-8', Buffer.from('E2B8CCB8', 'hex'), '\ufffd\u0338');
 test('utf-8', Buffer.from('E2FBCC01', 'hex'), '\ufffd\ufffd\ufffd\u0001');
 test('utf-8', Buffer.from('CCB8CDB9', 'hex'), '\u0338\u0379');
 // CESU-8 of U+1D40D
-test('utf-8', Buffer.from('EDA0B5EDB08D', 'hex'), '\ufffd\ufffd');
+
+// Disabled - V8 is changing the behavior related to overlong sequence / invalid
+// code point handling. See
+// https://chromium-review.googlesource.com/c/v8/v8/+/671020 for more
+// information.
+
+// test('utf-8', Buffer.from('EDA0B5EDB08D', 'hex'), '\ufffd\ufffd');
 
 // UCS-2
 test('ucs2', Buffer.from('ababc', 'ucs2'), 'ababc');


### PR DESCRIPTION
It relies on incorrect incorrect UTF-8 handling behavior in V8.
