### PR TITLE
Remove usage of --harmony-sharedarraybuffer flag

### DIFF
--- a/test/parallel/test-buffer-sharedarraybuffer.js
+++ b/test/parallel/test-buffer-sharedarraybuffer.js
@@ -1,6 +1,5 @@
 /*global SharedArrayBuffer*/
 'use strict';
-// Flags: --harmony-sharedarraybuffer
 
 require('../common');
 const assert = require('assert');

--- a/test/parallel/test-v8-serdes-sharedarraybuffer.js
+++ b/test/parallel/test-v8-serdes-sharedarraybuffer.js
@@ -1,6 +1,5 @@
 /*global SharedArrayBuffer*/
 'use strict';
-// Flags: --harmony-sharedarraybuffer
 
 const common = require('../common');
 const assert = require('assert');


### PR DESCRIPTION
It has been enabled by default since v8 @ 7662e063.