### PR TITLE
node-gyp: support for Chromium versions of Python

### DIFF
--- a/deps/npm/node_modules/node-gyp/lib/configure.js
+++ b/deps/npm/node_modules/node-gyp/lib/configure.js
@@ -459,6 +459,10 @@ PythonFinder.prototype = {
         this.log.silly('stripping "rc" identifier from version')
         version = version.replace(/rc(.*)$/ig, '')
       }
+      if (~version.indexOf('chromium')) {
+        this.log.silly('stripping "chromium" identifier from version')
+        version = version.replace(/chromium(.*)$/ig, '')
+      }
       var range = semver.Range('>=2.5.0 <3.0.0')
       var valid = false
       try {


### PR DESCRIPTION
This adds support for Chromium-specific version of Python, e.g v2.7.14chromium14.

##### Checklist
- [x] `make -j4 test` (UNIX)
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
deps
