### PR TITLE
Request code cache explicitly. 

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -689,8 +689,6 @@ class ContextifyScript : public BaseObject {
 
     if (source.GetCachedData() != nullptr)
       compile_options = ScriptCompiler::kConsumeCodeCache;
-    else if (produce_cached_data)
-      compile_options = ScriptCompiler::kProduceCodeCache;
 
     Context::Scope scope(maybe_context.FromMaybe(env->context()));
 
@@ -713,8 +711,9 @@ class ContextifyScript : public BaseObject {
       args.This()->Set(
           env->cached_data_rejected_string(),
           Boolean::New(env->isolate(), source.GetCachedData()->rejected));
-    } else if (compile_options == ScriptCompiler::kProduceCodeCache) {
-      const ScriptCompiler::CachedData* cached_data = source.GetCachedData();
+    } else if (produce_cached_data) {
+      const ScriptCompiler::CachedData* cached_data =
+        ScriptCompiler::CreateCodeCache(v8_script.ToLocalChecked(), code);
       bool cached_data_produced = cached_data != nullptr;
       if (cached_data_produced) {
         MaybeLocal<Object> buf = Buffer::Copy(


### PR DESCRIPTION
Request code cache explicitly. Earlier we used to produce code cache along with compile. Now V8 has added an API to request code cache. Support for producing code cache along with compile will be removed soon

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)
[src] request the code cache explicitly

Earlier the code cache was generated along with compile requests.
V8 now has an API to request the code cache. This cl uses the new
API to request code cache. In future, V8 will no longer produce code
cache along with compile requests.

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src
