### PR TITLE
test: do not expect code field on V8 SFI

### DIFF
--- a/test/parallel/test-postmortem-metadata.js
+++ b/test/parallel/test-postmortem-metadata.js
@@ -93,7 +93,6 @@ function getExpectedSymbols() {
     'v8dbg_class_Script__source__Object',
     'v8dbg_class_SeqOneByteString__chars__char',
     'v8dbg_class_SeqTwoByteString__chars__char',
-    'v8dbg_class_SharedFunctionInfo__code__Code',
     'v8dbg_class_SharedFunctionInfo__compiler_hints__int',
     'v8dbg_class_SharedFunctionInfo__end_position__int',
     'v8dbg_class_SharedFunctionInfo__function_identifier__Object',


### PR DESCRIPTION
V8 is removing the code field on its SharedFunctionInfo object, so do
not expect it in heap snapshots.

Refs: https://chromium-review.googlesource.com/952452

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
