### PR TITLE
Temporarily remove checks for soon to be removed SFI fields.

### DIFF
--- a/test/parallel/test-postmortem-metadata.js
+++ b/test/parallel/test-postmortem-metadata.js
@@ -97,8 +97,8 @@ function getExpectedSymbols() {
     'v8dbg_class_SharedFunctionInfo__end_position__int',
     'v8dbg_class_SharedFunctionInfo__function_identifier__Object',
     'v8dbg_class_SharedFunctionInfo__internal_formal_parameter_count__int',
-    'v8dbg_class_SharedFunctionInfo__raw_name__Object',
-    'v8dbg_class_SharedFunctionInfo__scope_info__ScopeInfo',
+    // TODO(camillobruni): enable once corresponding V8 CL has landed.
+    // 'v8dbg_class_SharedFunctionInfo__name_or_scope_info__Object',
     'v8dbg_class_SharedFunctionInfo__script__Object',
     'v8dbg_class_SharedFunctionInfo__start_position_and_type__int',
     'v8dbg_class_SlicedString__offset__SMI',


### PR DESCRIPTION
This PR temporarily disables the postmortem-metadata fields tests since I'm combining fields on the SFI to reduce memory consumption.
So far the SFI has a separate name and scope_info field which are going to be combined. If a ScopeInfo is present, the name is stored there. Until the V8 CL lands, we have to disable the failing tests.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
