### PR TITLE
test: expect "flags" field on SharedFunctionInfo

### DIFF
--- a/test/parallel/test-postmortem-metadata.js
+++ b/test/parallel/test-postmortem-metadata.js
@@ -93,8 +93,7 @@ function getExpectedSymbols() {
     'v8dbg_class_Script__source__Object',
     'v8dbg_class_SeqOneByteString__chars__char',
     'v8dbg_class_SeqTwoByteString__chars__char',
-    // TODO(leszekswirsk): enable once corresponding V8 CL has landed.
-    // 'v8dbg_class_SharedFunctionInfo__compiler_hints__int',
+    'v8dbg_class_SharedFunctionInfo__flags__int',
     'v8dbg_class_SharedFunctionInfo__end_position__int',
     'v8dbg_class_SharedFunctionInfo__function_identifier__Object',
     'v8dbg_class_SharedFunctionInfo__internal_formal_parameter_count__int',


### PR DESCRIPTION
Expect a "flags" field on V8 SharedFunctionInfo, renamed from
compiler_hints.

Only pull in once V8 is updated to include
https://chromium-review.googlesource.com/c/v8/v8/+/982012.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
