### PR TITLE
Enhancements to --build-v8-with-gn

### DIFF
--- a/configure
+++ b/configure
@@ -557,6 +557,12 @@ parser.add_option('--build-v8-with-gn',
     dest='build_v8_with_gn',
     default=False,
     help='build V8 using GN instead of gyp')
+parser.add_option('--build-v8-with-gn-use-goma',
+    action='store_true',
+    dest='build_v8_with_gn_use_goma',
+    default=False,
+    help='For Googlers: Enable use_goma=true for building v8')
+
 
 # Create compile_commands.json in out/Debug and out/Release.
 parser.add_option('-C',
@@ -1054,6 +1060,7 @@ def configure_v8(o):
     print('Fetching dependencies to build V8 with GN')
     options.build_v8_with_gn = FetchDeps(v8_path)
   o['variables']['build_v8_with_gn'] = b(options.build_v8_with_gn)
+  o['variables']['build_v8_with_gn_use_goma'] = b(options.build_v8_with_gn_use_goma)
 
 
 def configure_openssl(o):

--- a/deps/v8/gypfiles/v8-monolithic.gyp
+++ b/deps/v8/gypfiles/v8-monolithic.gyp
@@ -26,16 +26,19 @@
       },
       'actions': [
         {
-          'action_name': 'build_with_gn',
+          'action_name': 'build_with_gn_generate_build_files',
+          # No need to list full set of inputs because after the initial
+          # generation, ninja (run by the next action), will check to see
+          # if build.ninja is stale.
           'inputs': [
-            '../tools//node/build_gn.py',
+            '../tools/node/build_gn.py',
           ],
           'outputs': [
-            '<(INTERMEDIATE_DIR)/gn/obj/libv8_monolith.a',
-            '<(INTERMEDIATE_DIR)/gn/args.gn',
+            '<(INTERMEDIATE_DIR)/gn/build.ninja',
           ],
           'action': [
-            '../tools//node/build_gn.py',
+            'python',
+            '../tools/node/build_gn.py',
             '--mode', '<(CONFIGURATION_NAME)',
             '--v8_path', '../',
             '--build_path', '<(INTERMEDIATE_DIR)/gn',
@@ -49,7 +52,31 @@
             '--flag', 'v8_optimized_debug=<(v8_optimized_debug)',
             '--flag', 'v8_enable_disassembler=<(v8_enable_disassembler)',
             '--flag', 'v8_postmortem_support=<(v8_postmortem_support)',
+            '--flag', 'use_goma=<(build_v8_with_gn_use_goma)',
           ],
+        },
+        {
+          'action_name': 'build_with_gn',
+          'inputs': [
+            '../tools/node/build_gn.py',
+            '<(INTERMEDIATE_DIR)/gn/build.ninja',
+          ],
+          # Specify a non-existent output to make the target permanently dirty.
+          # Alternatively, a depfile could be used, but then two dirty checks
+          # would run: one by outer the build tool, and one by build_gn.py.
+          'outputs': [
+            '<(v8_base)',
+            'does-not-exist',
+          ],
+          'action': [
+            'python',
+            '../tools/node/build_gn.py',
+            '--build_path', '<(INTERMEDIATE_DIR)/gn',
+            '--v8_path', '../',
+            '--build',
+          ],
+          # Allows sub-ninja's build progress to be printed.
+          'ninja_use_console': 1,
         },
       ],
     },

--- a/deps/v8/tools/node/build_gn.py
+++ b/deps/v8/tools/node/build_gn.py
@@ -46,7 +46,6 @@ def FindGn(options):
   return os.path.join(options.v8_path, "buildtools", os_path, "gn")
 
 def GenerateBuildFiles(options):
-  print "Setting GN args."
   gn = FindGn(options)
   gn_args = []
   gn_args.extend(GN_ARGS)
@@ -56,47 +55,57 @@ def GenerateBuildFiles(options):
     flag = flag.replace("target_cpu=ia32", "target_cpu=\"x86\"")
     gn_args.append(flag)
   if options.mode == "DEBUG":
-    gn_args.append("is_debug = true")
+    gn_args.append("is_debug=true")
   else:
-    gn_args.append("is_debug = false")
+    gn_args.append("is_debug=false")
 
-  if not os.path.isdir(options.build_path):
-    os.makedirs(options.build_path)
-  with open(os.path.join(options.build_path, "args.gn"), "w") as args_file:
-    args_file.write("\n".join(gn_args))
-  subprocess.check_call([gn, "gen", "-C", options.build_path],
-                        cwd=options.v8_path)
+  args = [gn, "gen", options.build_path, "-q",
+          "--args=" + ' '.join(gn_args)]
+  subprocess.check_call(args, cwd=options.v8_path)
 
 def Build(options):
-  print "Building."
   depot_tools = node_common.EnsureDepotTools(options.v8_path, False)
   ninja = os.path.join(depot_tools, "ninja")
-  subprocess.check_call([ninja, "-v", "-C", options.build_path, BUILD_TARGET],
-                        cwd=options.v8_path)
+  if sys.platform == 'win32':
+    # Required because there is an extension-less file called "ninja".
+    ninja += '.exe'
+  args = [ninja, "-C", options.build_path, BUILD_TARGET]
+
+  with open(os.path.join(options.build_path, 'args.gn')) as f:
+    if 'use_goma = true' in f.read():
+      args += ["-j500"]
+
+  subprocess.check_call(args, cwd=options.v8_path)
 
 def ParseOptions(args):
   parser = argparse.ArgumentParser(
       description="Build %s with GN" % BUILD_TARGET)
   parser.add_argument("--mode", help="Build mode (Release/Debug)")
-  parser.add_argument("--v8_path", help="Path to V8")
-  parser.add_argument("--build_path", help="Path to build result")
+  parser.add_argument("--v8_path", help="Path to V8", required=True)
+  parser.add_argument("--build_path", help="Path to build result",
+                      required=True)
   parser.add_argument("--flag", help="Translate GYP flag to GN",
                       action="append")
   parser.add_argument("--host_os", help="Current operating system")
+  parser.add_argument("--build", help="Run ninja as opposed to gn gen.",
+                      action="store_true")
   options = parser.parse_args(args)
 
-  assert options.host_os
-  assert options.mode == "Debug" or options.mode == "Release"
-
-  assert options.v8_path
-  options.v8_path = os.path.abspath(options.v8_path)
-  assert os.path.isdir(options.v8_path)
-
-  assert options.build_path
   options.build_path = os.path.abspath(options.build_path)
+
+  if not options.build:
+    assert options.host_os
+    assert options.mode == "Debug" or options.mode == "Release"
+
+    options.v8_path = os.path.abspath(options.v8_path)
+    assert os.path.isdir(options.v8_path)
+
   return options
+
 
 if __name__ == "__main__":
   options = ParseOptions(sys.argv[1:])
-  GenerateBuildFiles(options)
-  Build(options)
+  if not options.build:
+    GenerateBuildFiles(options)
+  else:
+    Build(options)


### PR DESCRIPTION
* Split "gn gen" and "ninja" invocations into two separate actions
* Make the ninja action use console pool so that progress is shown
* Add --build-v8-with-gn-use-goma for faster builds (for Googlers)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
