### PR TITLE
test: fix scriptParsed event expectations

### DIFF
--- a/test/sequential/test-inspector-scriptparsed-context.js
+++ b/test/sequential/test-inspector-scriptparsed-context.js
@@ -17,20 +17,11 @@ const script = `
     outer: false,
     inner: true
   });
+  const script = new vm.Script("outer");
   debugger;
 
-  const scriptMain = new vm.Script("outer");
-  debugger;
-
-  const scriptContext = new vm.Script("inner", {
-    [kParsingContext]: context
-  });
-  debugger;
-
-  assert.strictEqual(scriptMain.runInThisContext(), true);
-  assert.strictEqual(scriptMain.runInContext(context), false);
-  assert.strictEqual(scriptContext.runInThisContext(), false);
-  assert.strictEqual(scriptContext.runInContext(context), true);
+  assert.strictEqual(script.runInThisContext(), true);
+  assert.strictEqual(script.runInContext(context), false);
   debugger;
 
   vm.runInContext('inner', context);
@@ -68,32 +59,22 @@ async function runTests() {
   const topContext = await getContext(session);
   await session.send({ 'method': 'Debugger.resume' });
   const childContext = await getContext(session);
-  await session.waitForBreakOnLine(13, '[eval]');
-
-  console.error('[test]', 'Script associated with current context by default');
-  await session.send({ 'method': 'Debugger.resume' });
-  await checkScriptContext(session, topContext);
-  await session.waitForBreakOnLine(16, '[eval]');
-
-  console.error('[test]', 'Script associated with selected context');
-  await session.send({ 'method': 'Debugger.resume' });
-  await checkScriptContext(session, childContext);
-  await session.waitForBreakOnLine(21, '[eval]');
+  await session.waitForBreakOnLine(14, '[eval]');
 
   console.error('[test]', 'Script is unbound');
   await session.send({ 'method': 'Debugger.resume' });
-  await session.waitForBreakOnLine(27, '[eval]');
+  await session.waitForBreakOnLine(18, '[eval]');
 
   console.error('[test]', 'vm.runInContext associates script with context');
   await session.send({ 'method': 'Debugger.resume' });
   await checkScriptContext(session, childContext);
-  await session.waitForBreakOnLine(30, '[eval]');
+  await session.waitForBreakOnLine(21, '[eval]');
 
   console.error('[test]', 'vm.runInNewContext associates script with context');
   await session.send({ 'method': 'Debugger.resume' });
   const thirdContext = await getContext(session);
   await checkScriptContext(session, thirdContext);
-  await session.waitForBreakOnLine(33, '[eval]');
+  await session.waitForBreakOnLine(24, '[eval]');
 
   console.error('[test]', 'vm.runInNewContext can contain debugger statements');
   await session.send({ 'method': 'Debugger.resume' });


### PR DESCRIPTION
As per [Node.js docs](https://nodejs.org/docs/latest/api/vm.html#vm_new_vm_script_code_options), `vm.Script` instance is not bound to any context.

However, this test was expecting otherwise and depended on implementation details which are going to change in https://chromium-review.googlesource.com/c/v8/v8/+/1013581.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
