### PR TITLE
Fix --use-clang-cl to actually use clang-cl

### DIFF
--- a/configure
+++ b/configure
@@ -1100,7 +1100,9 @@ def configure_v8(o):
     o['variables']['build_v8_with_gn_max_load'] = (
         options.build_v8_with_gn_max_load)
     o['variables']['build_v8_with_gn_bundled_win_toolchain'] = (
-        os.environ['DEPOT_TOOLS_WIN_TOOLCHAIN'])
+        os.environ.get('DEPOT_TOOLS_WIN_TOOLCHAIN', ''))
+    o['variables']['build_v8_with_gn_bundled_win_toolchain_root'] = (
+        os.environ.get('DEPOT_TOOLS_WIN_TOOLCHAIN_ROOT', ''))
     o['variables']['build_v8_with_gn_depot_tools'] = depot_tools
 
 

--- a/configure
+++ b/configure
@@ -610,8 +610,6 @@ if options.use_clang_cl:
   else:
     clang_base_path = os.path.abspath(os.path.join(
         'deps', 'v8', 'third_party', 'llvm-build', 'Release+Asserts'))
-  # CC sets the path for GYP-compiled files.
-  os.environ['CC'] = os.path.join(clang_base_path, 'bin', 'clang-cl.exe')
   # GN arg sets the path for --build-v8-using-gn.
   if options.build_v8_with_gn_extra_gn_args:
     options.build_v8_with_gn_extra_gn_args += ' '
@@ -1529,6 +1527,11 @@ if 'make_fips_settings' in output:
   del output['make_fips_settings']
   write('config_fips.gypi', do_not_edit +
         pprint.pformat(config_fips, indent=2) + '\n')
+
+if options.use_clang_cl:
+  make_global_settings = output.setdefault('make_global_settings', [])
+  make_global_settings.append(
+      ['CC', os.path.join(clang_base_path, 'bin', 'clang-cl')])
 
 # make_global_settings should be a root level element too
 if 'make_global_settings' in output:

--- a/deps/v8/gypfiles/v8-monolithic.gyp
+++ b/deps/v8/gypfiles/v8-monolithic.gyp
@@ -71,6 +71,11 @@
                 '--extra-gn-args', '<(build_v8_with_gn_extra_gn_args)',
               ],
             }],
+            ['build_v8_with_gn_bundled_win_toolchain_root != ""', {
+              'action': [
+                '--bundled-win-toolchain-root', '<(build_v8_with_gn_bundled_win_toolchain_root)',
+              ],
+            }],
           ],
         },
         {

--- a/deps/v8/tools/node/build_gn.py
+++ b/deps/v8/tools/node/build_gn.py
@@ -103,6 +103,8 @@ def ParseOptions(args):
   parser.add_argument("--host_os", help="Current operating system")
   parser.add_argument("--bundled-win-toolchain",
                       help="Value for DEPOT_TOOLS_WIN_TOOLCHAIN")
+  parser.add_argument("--bundled-win-toolchain-root",
+                      help="Value for DEPOT_TOOLS_WIN_TOOLCHAIN_ROOT")
   parser.add_argument("--depot-tools", help="Absolute path to depot_tools")
   parser.add_argument("--extra-gn-args", help="Additional GN args")
   parser.add_argument("--build", help="Run ninja as opposed to gn gen.",

--- a/deps/v8/tools/node/build_gn.py
+++ b/deps/v8/tools/node/build_gn.py
@@ -128,7 +128,7 @@ if __name__ == "__main__":
   # Build can result in running gn gen, so need to set environment variables
   # for build as well as generate.
   os.environ['DEPOT_TOOLS_WIN_TOOLCHAIN'] = options.bundled_win_toolchain
-  os.environ['PATH'] += os.path.pathsep + options.depot_tools
+  os.environ['PATH'] = options.depot_tools + os.path.pathsep + os.environ['PATH']
   if not options.build:
     GenerateBuildFiles(options)
   else:

--- a/src/node_win32_perfctr_provider.cc
+++ b/src/node_win32_perfctr_provider.cc
@@ -118,9 +118,6 @@ PPERF_COUNTERSET_INSTANCE perfctr_instance;
 
 namespace node {
 
-
-EXTERN_C DECLSPEC_SELECTANY HANDLE NodeCounterProvider = nullptr;
-
 void InitPerfCountersWin32() {
   ULONG status;
   PERF_PROVIDER_CONTEXT providerContext;

--- a/src/node_win32_perfctr_provider.h
+++ b/src/node_win32_perfctr_provider.h
@@ -32,7 +32,7 @@
 
 namespace node {
 
-extern HANDLE NodeCounterProvider;
+EXTERN_C HANDLE NodeCounterProvider;
 
 INLINE bool NODE_COUNTER_ENABLED() { return NodeCounterProvider != nullptr; }
 void NODE_COUNT_HTTP_SERVER_REQUEST();

--- a/tools/js2c.py
+++ b/tools/js2c.py
@@ -31,6 +31,8 @@
 # char arrays. It is used for embedded JavaScript code in the V8
 # library.
 
+import ast
+import json
 import os
 import re
 import sys
@@ -292,11 +294,11 @@ def JS2C(source, target):
         split = split[1:]
       name = '/'.join(split)
 
-    # if its a gypi file we're going to want it as json
-    # later on anyway, so get it out of the way now
+    # Convert gypi to json. This means line number will not match up to the
+    # original file, but is equired to properly escape strings.
     if name.endswith(".gypi"):
-      lines = re.sub(r'#.*?\n', '', lines)
-      lines = re.sub(r'\'', '"', lines)
+      obj = ast.literal_eval(lines)
+      lines = json.dumps(obj, indent=2)
     name = name.split('.', 1)[0]
     var = name.replace('-', '_').replace('/', '_')
     key = '%s_key' % var


### PR DESCRIPTION
A few fixes:
 * Fixed the flag
 * Fixed one compile error that surfaces with clang-cl
 * Fix js2c.py's conversion of .gypi -> .json
 * Fixed a depot_tools issue unrelated to this change, but that I realized was incorrect in the previous pull request.