### PR TITLE
[build] Escape quotations in gypi files included in binary

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -731,6 +731,7 @@
           'action_name': 'node_js2c',
           'process_outputs_as_sources': 1,
           'inputs': [
+            'tools/js2c.py',
             '<@(library_files)',
             './config.gypi',
             'tools/check_macros.py'
@@ -756,7 +757,9 @@
             'python',
             'tools/js2c.py',
             '<@(_outputs)',
-            '<@(_inputs)',
+            '<@(library_files)',
+            './config.gypi',
+            'tools/check_macros.py'
           ],
         },
       ],

--- a/tools/js2c.py
+++ b/tools/js2c.py
@@ -296,6 +296,7 @@ def JS2C(source, target):
     # later on anyway, so get it out of the way now
     if name.endswith(".gypi"):
       lines = re.sub(r'#.*?\n', '', lines)
+      lines = re.sub(r'"', '\\"', lines)
       lines = re.sub(r'\'', '"', lines)
     name = name.split('.', 1)[0]
     var = name.replace('-', '_').replace('/', '_')


### PR DESCRIPTION
The js2c script does not properly handle double quotes in gypi files. This escapes double quotes before all single quotes are turned into double quotes, as otherwise json parsing fails on startup.

This also adds the js2c script itself to the action inputs as otherwise the incremental build doesn't run the
action on changes to the script.