### PR TITLE
tools: properly convert .gypi -> .json in js2c.py

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -731,6 +731,8 @@
           'action_name': 'node_js2c',
           'process_outputs_as_sources': 1,
           'inputs': [
+            # TODO(machenbach): This should include 'tools/js2c.py' to properly
+            # re-run on script changes.
             '<@(library_files)',
             './config.gypi',
             'tools/check_macros.py'

--- a/tools/js2c.py
+++ b/tools/js2c.py
@@ -31,6 +31,8 @@
 # char arrays. It is used for embedded JavaScript code in the V8
 # library.
 
+import ast
+import json
 import os
 import re
 import sys
@@ -292,11 +294,11 @@ def JS2C(source, target):
         split = split[1:]
       name = '/'.join(split)
 
-    # if its a gypi file we're going to want it as json
-    # later on anyway, so get it out of the way now
+    # Convert gypi to json. This means line numbers will not match up to the
+    # original file, but it is required to properly escape strings.
     if name.endswith(".gypi"):
-      lines = re.sub(r'#.*?\n', '', lines)
-      lines = re.sub(r'\'', '"', lines)
+      obj = ast.literal_eval(lines)
+      lines = json.dumps(obj, indent=2)
     name = name.split('.', 1)[0]
     var = name.replace('-', '_').replace('/', '_')
     key = '%s_key' % var


### PR DESCRIPTION
It was breaking when .gypi strings had quotes in them. e.g.:
  'foo': 'bar="baz"'

This also adds ths js2c script to its action inputs as otherwise incremental builds don't re-run on changes to the script.