### PR TITLE
build: fix build error for clang-cl

### DIFF
--- a/src/node_win32_perfctr_provider.cc
+++ b/src/node_win32_perfctr_provider.cc
@@ -119,7 +119,7 @@ PPERF_COUNTERSET_INSTANCE perfctr_instance;
 namespace node {
 
 
-EXTERN_C DECLSPEC_SELECTANY HANDLE NodeCounterProvider = nullptr;
+HANDLE NodeCounterProvider = nullptr;
 
 void InitPerfCountersWin32() {
   ULONG status;


### PR DESCRIPTION
Clang complains that the declaration and definition differs (`extern` vs `extern "C"`). This fixes the issue.