### PR TITLE
Temporarily comment out removed Context fields

### DIFF
--- a/test/parallel/test-postmortem-metadata.js
+++ b/test/parallel/test-postmortem-metadata.js
@@ -105,7 +105,8 @@ function getExpectedSymbols() {
     'v8dbg_class_SlicedString__parent__String',
     'v8dbg_class_String__length__SMI',
     'v8dbg_class_ThinString__actual__String',
-    'v8dbg_context_idx_closure',
+    // TODO(camillobruni): enable once corresponding V8 CL has landed.
+    // 'v8dbg_context_idx_closure',
     'v8dbg_context_idx_prev',
     'v8dbg_context_min_slots',
     'v8dbg_frametype_ArgumentsAdaptorFrame',


### PR DESCRIPTION
test: Comment out changed Context fields in test-postmortem-metadata.js

This is preparatory work to land a memory improvement CL in V8.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
