### PR TITLE
Use modern v8::Platform worker threads APIs.

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -301,7 +301,7 @@ static struct {
   }
 
   void DrainVMTasks(Isolate* isolate) {
-    platform_->DrainBackgroundTasks(isolate);
+    platform_->DrainTasks(isolate);
   }
 
   void CancelVMTasks(Isolate* isolate) {

--- a/src/node.h
+++ b/src/node.h
@@ -220,7 +220,7 @@ class Environment;
 class MultiIsolatePlatform : public v8::Platform {
  public:
   virtual ~MultiIsolatePlatform() { }
-  virtual void DrainBackgroundTasks(v8::Isolate* isolate) = 0;
+  virtual void DrainTasks(v8::Isolate* isolate) = 0;
   virtual void CancelPendingDelayedTasks(v8::Isolate* isolate) = 0;
 
   // These will be called by the `IsolateData` creation/destruction functions.

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -16,48 +16,50 @@ using v8::Platform;
 using v8::Task;
 using v8::TracingController;
 
-static void BackgroundRunner(void* data) {
-  TaskQueue<Task>* background_tasks = static_cast<TaskQueue<Task>*>(data);
-  while (std::unique_ptr<Task> task = background_tasks->BlockingPop()) {
+namespace {
+
+static void WorkerThreadMain(void* data) {
+  TaskQueue<Task>* pending_worker_tasks = static_cast<TaskQueue<Task>*>(data);
+  while (std::unique_ptr<Task> task = pending_worker_tasks->BlockingPop()) {
     task->Run();
-    background_tasks->NotifyOfCompletion();
+    pending_worker_tasks->NotifyOfCompletion();
   }
 }
 
-BackgroundTaskRunner::BackgroundTaskRunner(int thread_pool_size) {
+}  // namespace
+
+WorkerThreadsTaskRunner::WorkerThreadsTaskRunner(int thread_pool_size) {
   for (int i = 0; i < thread_pool_size; i++) {
     std::unique_ptr<uv_thread_t> t { new uv_thread_t() };
-    if (uv_thread_create(t.get(), BackgroundRunner, &background_tasks_) != 0)
+    if (uv_thread_create(t.get(), WorkerThreadMain,
+                         &pending_worker_tasks_) != 0) {
       break;
+    }
     threads_.push_back(std::move(t));
   }
 }
 
-void BackgroundTaskRunner::PostTask(std::unique_ptr<Task> task) {
-  background_tasks_.Push(std::move(task));
+void WorkerThreadsTaskRunner::PostTask(std::unique_ptr<Task> task) {
+  pending_worker_tasks_.Push(std::move(task));
 }
 
-void BackgroundTaskRunner::PostIdleTask(std::unique_ptr<v8::IdleTask> task) {
+void WorkerThreadsTaskRunner::PostDelayedTask(std::unique_ptr<v8::Task> task,
+                                              double delay_in_seconds) {
   UNREACHABLE();
 }
 
-void BackgroundTaskRunner::PostDelayedTask(std::unique_ptr<v8::Task> task,
-                                           double delay_in_seconds) {
-  UNREACHABLE();
+void WorkerThreadsTaskRunner::BlockingDrain() {
+  pending_worker_tasks_.BlockingDrain();
 }
 
-void BackgroundTaskRunner::BlockingDrain() {
-  background_tasks_.BlockingDrain();
-}
-
-void BackgroundTaskRunner::Shutdown() {
-  background_tasks_.Stop();
+void WorkerThreadsTaskRunner::Shutdown() {
+  pending_worker_tasks_.Stop();
   for (size_t i = 0; i < threads_.size(); i++) {
     CHECK_EQ(0, uv_thread_join(threads_[i].get()));
   }
 }
 
-size_t BackgroundTaskRunner::NumberOfAvailableBackgroundThreads() const {
+int WorkerThreadsTaskRunner::NumberOfWorkerThreads() const {
   return threads_.size();
 }
 
@@ -120,8 +122,8 @@ NodePlatform::NodePlatform(int thread_pool_size,
     TracingController* controller = new TracingController();
     tracing_controller_.reset(controller);
   }
-  background_task_runner_ =
-      std::make_shared<BackgroundTaskRunner>(thread_pool_size);
+  worker_thread_task_runner_ =
+      std::make_shared<WorkerThreadsTaskRunner>(thread_pool_size);
 }
 
 void NodePlatform::RegisterIsolate(IsolateData* isolate_data, uv_loop_t* loop) {
@@ -147,7 +149,7 @@ void NodePlatform::UnregisterIsolate(IsolateData* isolate_data) {
 }
 
 void NodePlatform::Shutdown() {
-  background_task_runner_->Shutdown();
+  worker_thread_task_runner_->Shutdown();
 
   {
     Mutex::ScopedLock lock(per_isolate_mutex_);
@@ -155,8 +157,8 @@ void NodePlatform::Shutdown() {
   }
 }
 
-size_t NodePlatform::NumberOfAvailableBackgroundThreads() {
-  return background_task_runner_->NumberOfAvailableBackgroundThreads();
+int NodePlatform::NumberOfWorkerThreads() {
+  return worker_thread_task_runner_->NumberOfWorkerThreads();
 }
 
 void PerIsolatePlatformData::RunForegroundTask(std::unique_ptr<Task> task) {
@@ -188,15 +190,12 @@ void PerIsolatePlatformData::CancelPendingDelayedTasks() {
   scheduled_delayed_tasks_.clear();
 }
 
-void NodePlatform::DrainBackgroundTasks(Isolate* isolate) {
+void NodePlatform::DrainTasks(Isolate* isolate) {
   std::shared_ptr<PerIsolatePlatformData> per_isolate = ForIsolate(isolate);
 
   do {
-    // Right now, there is no way to drain only background tasks associated
-    // with a specific isolate, so this sometimes does more work than
-    // necessary. In the long run, that functionality is probably going to
-    // be available anyway, though.
-    background_task_runner_->BlockingDrain();
+    // Worker tasks aren't associated with an Isolate.
+    worker_thread_task_runner_->BlockingDrain();
   } while (per_isolate->FlushForegroundTasksInternal());
 }
 
@@ -230,10 +229,16 @@ bool PerIsolatePlatformData::FlushForegroundTasksInternal() {
   return did_work;
 }
 
-void NodePlatform::CallOnBackgroundThread(Task* task,
-                                          ExpectedRuntime expected_runtime) {
-  background_task_runner_->PostTask(std::unique_ptr<Task>(task));
+void NodePlatform::CallOnWorkerThread(std::unique_ptr<v8::Task> task) {
+  worker_thread_task_runner_->PostTask(std::move(task));
 }
+
+void NodePlatform::CallDelayedOnWorkerThread(std::unique_ptr<v8::Task> task,
+                                             double delay_in_seconds) {
+  worker_thread_task_runner_->PostDelayedTask(std::move(task),
+                                              delay_in_seconds);
+}
+
 
 std::shared_ptr<PerIsolatePlatformData>
 NodePlatform::ForIsolate(Isolate* isolate) {
@@ -263,11 +268,6 @@ void NodePlatform::CancelPendingDelayedTasks(v8::Isolate* isolate) {
 }
 
 bool NodePlatform::IdleTasksEnabled(Isolate* isolate) { return false; }
-
-std::shared_ptr<v8::TaskRunner>
-NodePlatform::GetBackgroundTaskRunner(Isolate* isolate) {
-  return background_task_runner_;
-}
 
 std::shared_ptr<v8::TaskRunner>
 NodePlatform::GetForegroundTaskRunner(Isolate* isolate) {

--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -89,23 +89,22 @@ class PerIsolatePlatformData :
   std::vector<DelayedTaskPointer> scheduled_delayed_tasks_;
 };
 
-// This acts as the single background task runner for all Isolates.
-class BackgroundTaskRunner : public v8::TaskRunner {
+// This acts as the single worker thread task runner for all Isolates.
+class WorkerThreadsTaskRunner {
  public:
-  explicit BackgroundTaskRunner(int thread_pool_size);
+  explicit WorkerThreadsTaskRunner(int thread_pool_size);
 
-  void PostTask(std::unique_ptr<v8::Task> task) override;
-  void PostIdleTask(std::unique_ptr<v8::IdleTask> task) override;
+  void PostTask(std::unique_ptr<v8::Task> task);
   void PostDelayedTask(std::unique_ptr<v8::Task> task,
-                       double delay_in_seconds) override;
-  bool IdleTasksEnabled() override { return false; };
+                       double delay_in_seconds);
 
   void BlockingDrain();
   void Shutdown();
 
-  size_t NumberOfAvailableBackgroundThreads() const;
+  int NumberOfWorkerThreads() const;
+
  private:
-  TaskQueue<v8::Task> background_tasks_;
+  TaskQueue<v8::Task> pending_worker_tasks_;
   std::vector<std::unique_ptr<uv_thread_t>> threads_;
 };
 
@@ -114,14 +113,15 @@ class NodePlatform : public MultiIsolatePlatform {
   NodePlatform(int thread_pool_size, v8::TracingController* tracing_controller);
   virtual ~NodePlatform() {}
 
-  void DrainBackgroundTasks(v8::Isolate* isolate) override;
+  void DrainTasks(v8::Isolate* isolate) override;
   void CancelPendingDelayedTasks(v8::Isolate* isolate) override;
   void Shutdown();
 
   // v8::Platform implementation.
-  size_t NumberOfAvailableBackgroundThreads() override;
-  void CallOnBackgroundThread(v8::Task* task,
-                              ExpectedRuntime expected_runtime) override;
+  int NumberOfWorkerThreads() override;
+  void CallOnWorkerThread(std::unique_ptr<v8::Task> task) override;
+  void CallDelayedOnWorkerThread(std::unique_ptr<v8::Task> task,
+                                 double delay_in_seconds) override;
   void CallOnForegroundThread(v8::Isolate* isolate, v8::Task* task) override;
   void CallDelayedOnForegroundThread(v8::Isolate* isolate, v8::Task* task,
                                      double delay_in_seconds) override;
@@ -135,8 +135,6 @@ class NodePlatform : public MultiIsolatePlatform {
   void RegisterIsolate(IsolateData* isolate_data, uv_loop_t* loop) override;
   void UnregisterIsolate(IsolateData* isolate_data) override;
 
-  std::shared_ptr<v8::TaskRunner> GetBackgroundTaskRunner(
-      v8::Isolate* isolate) override;
   std::shared_ptr<v8::TaskRunner> GetForegroundTaskRunner(
       v8::Isolate* isolate) override;
 
@@ -148,7 +146,7 @@ class NodePlatform : public MultiIsolatePlatform {
                      std::shared_ptr<PerIsolatePlatformData>> per_isolate_;
 
   std::unique_ptr<v8::TracingController> tracing_controller_;
-  std::shared_ptr<BackgroundTaskRunner> background_task_runner_;
+  std::shared_ptr<WorkerThreadsTaskRunner> worker_thread_task_runner_;
 };
 
 }  // namespace node


### PR DESCRIPTION
Precursor to removing deprecated APIs on the v8 side @
https://chromium-review.googlesource.com/c/v8/v8/+/1045310

Nomenclature has been updated from "background threads" to "worker threads".

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
