### PR TITLE
tests: disable inspector tests before V8 roll

### DIFF
--- a/test/sequential/test-inspector-async-hook-setup-at-inspect-brk.js
+++ b/test/sequential/test-inspector-async-hook-setup-at-inspect-brk.js
@@ -1,6 +1,7 @@
 // Flags: --expose-internals
 'use strict';
 const common = require('../common');
+common.skip('skip until V8 roll');
 common.skipIfInspectorDisabled();
 common.skipIf32Bits();
 common.crashOnUnhandledRejection();
@@ -15,7 +16,7 @@ setTimeout(() => {
 `;
 
 async function skipBreakpointAtStart(session) {
-  await session.waitForBreakOnLine(0, '[eval]');
+  await session.waitForBreakOnLine(3, '[eval]');
   await session.send({ 'method': 'Debugger.resume' });
 }
 

--- a/test/sequential/test-inspector-async-stack-traces-promise-then.js
+++ b/test/sequential/test-inspector-async-stack-traces-promise-then.js
@@ -1,6 +1,7 @@
 // Flags: --expose-internals
 'use strict';
 const common = require('../common');
+common.skip('skip until V8 roll');
 common.skipIfInspectorDisabled();
 common.skipIf32Bits();
 common.crashOnUnhandledRejection();
@@ -32,7 +33,7 @@ async function runTests() {
     { 'method': 'Runtime.runIfWaitingForDebugger' }
   ]);
 
-  await session.waitForBreakOnLine(0, '[eval]');
+  await session.waitForBreakOnLine(2, '[eval]');
   await session.send({ 'method': 'Debugger.resume' });
 
   console.error('[test] Waiting for break1');

--- a/test/sequential/test-inspector-async-stack-traces-set-interval.js
+++ b/test/sequential/test-inspector-async-stack-traces-set-interval.js
@@ -1,6 +1,7 @@
 // Flags: --expose-internals
 'use strict';
 const common = require('../common');
+common.skip('skip until V8 roll');
 common.skipIfInspectorDisabled();
 common.skipIf32Bits();
 common.crashOnUnhandledRejection();
@@ -11,7 +12,7 @@ const script = 'setInterval(() => { debugger; }, 50);';
 
 async function skipFirstBreakpoint(session) {
   console.log('[test]', 'Skipping the first breakpoint in the eval script');
-  await session.waitForBreakOnLine(0, '[eval]');
+  await session.waitForBreakOnLine(2, '[eval]');
   await session.send({ 'method': 'Debugger.resume' });
 }
 

--- a/test/sequential/test-inspector-break-e.js
+++ b/test/sequential/test-inspector-break-e.js
@@ -1,7 +1,7 @@
 // Flags: --expose-internals
 'use strict';
 const common = require('../common');
-
+common.skip('skip until V8 roll');
 common.skipIfInspectorDisabled();
 common.crashOnUnhandledRejection();
 
@@ -16,7 +16,7 @@ async function runTests() {
     { 'method': 'Debugger.enable' },
     { 'method': 'Runtime.runIfWaitingForDebugger' }
   ]);
-  await session.waitForBreakOnLine(0, '[eval]');
+  await session.waitForBreakOnLine(2, '[eval]');
   await session.runToCompletion();
   assert.strictEqual(0, (await instance.expectShutdown()).exitCode);
 }

--- a/test/sequential/test-inspector-exception.js
+++ b/test/sequential/test-inspector-exception.js
@@ -1,6 +1,7 @@
 // Flags: --expose-internals
 'use strict';
 const common = require('../common');
+common.skip('skip until V8 roll');
 const fixtures = require('../common/fixtures');
 
 common.skipIfInspectorDisabled();
@@ -29,7 +30,7 @@ async function testBreakpointOnStart(session) {
   ];
 
   await session.send(commands);
-  await session.waitForBreakOnLine(0, script);
+  await session.waitForBreakOnLine(21, script);
 }
 
 

--- a/test/sequential/test-inspector-scriptparsed-context.js
+++ b/test/sequential/test-inspector-scriptparsed-context.js
@@ -1,6 +1,7 @@
 // Flags: --expose-internals
 'use strict';
 const common = require('../common');
+common.skip('skip until V8 roll');
 common.skipIfInspectorDisabled();
 common.crashOnUnhandledRejection();
 const { NodeInstance } = require('../common/inspector-helper.js');
@@ -52,7 +53,7 @@ async function runTests() {
     { 'method': 'Debugger.enable' },
     { 'method': 'Runtime.runIfWaitingForDebugger' }
   ]);
-  await session.waitForBreakOnLine(0, '[eval]');
+  await session.waitForBreakOnLine(4, '[eval]');
 
   await session.send({ 'method': 'Runtime.enable' });
   await getContext(session);


### PR DESCRIPTION
V8 roll will improve break locations for node --inspect-brk -e case.