### PR TITLE
platform: Initialize PerIsolateData eagerly

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -33,7 +33,7 @@ IsolateData::IsolateData(Isolate* isolate,
     zero_fill_field_(zero_fill_field),
     platform_(platform) {
   if (platform_ != nullptr)
-    platform_->RegisterIsolate(this, event_loop);
+    platform_->RegisterIsolate(isolate_, event_loop);
 
   // Create string and private symbol properties as internalized one byte
   // strings after the platform is properly initialized.
@@ -72,7 +72,7 @@ IsolateData::IsolateData(Isolate* isolate,
 
 IsolateData::~IsolateData() {
   if (platform_ != nullptr)
-    platform_->UnregisterIsolate(this);
+    platform_->UnregisterIsolate(isolate_);
   if (cpu_profiler_ != nullptr)
     cpu_profiler_->Dispose();
 }

--- a/src/node.h
+++ b/src/node.h
@@ -229,9 +229,9 @@ class MultiIsolatePlatform : public v8::Platform {
   virtual void CancelPendingDelayedTasks(v8::Isolate* isolate) = 0;
 
   // These will be called by the `IsolateData` creation/destruction functions.
-  virtual void RegisterIsolate(IsolateData* isolate_data,
+  virtual void RegisterIsolate(v8::Isolate* isolate,
                                struct uv_loop_s* loop) = 0;
-  virtual void UnregisterIsolate(IsolateData* isolate_data) = 0;
+  virtual void UnregisterIsolate(v8::Isolate* isolate) = 0;
 };
 
 // Creates a new isolate with Node.js-specific settings.

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -126,8 +126,7 @@ NodePlatform::NodePlatform(int thread_pool_size,
       std::make_shared<WorkerThreadsTaskRunner>(thread_pool_size);
 }
 
-void NodePlatform::RegisterIsolate(IsolateData* isolate_data, uv_loop_t* loop) {
-  Isolate* isolate = isolate_data->isolate();
+void NodePlatform::RegisterIsolate(Isolate* isolate, uv_loop_t* loop) {
   Mutex::ScopedLock lock(per_isolate_mutex_);
   std::shared_ptr<PerIsolatePlatformData> existing = per_isolate_[isolate];
   if (existing) {
@@ -138,8 +137,7 @@ void NodePlatform::RegisterIsolate(IsolateData* isolate_data, uv_loop_t* loop) {
   }
 }
 
-void NodePlatform::UnregisterIsolate(IsolateData* isolate_data) {
-  Isolate* isolate = isolate_data->isolate();
+void NodePlatform::UnregisterIsolate(Isolate* isolate) {
   Mutex::ScopedLock lock(per_isolate_mutex_);
   std::shared_ptr<PerIsolatePlatformData> existing = per_isolate_[isolate];
   CHECK(existing);

--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -138,8 +138,8 @@ class NodePlatform : public MultiIsolatePlatform {
   // flushing.
   bool FlushForegroundTasks(v8::Isolate* isolate);
 
-  void RegisterIsolate(IsolateData* isolate_data, uv_loop_t* loop) override;
-  void UnregisterIsolate(IsolateData* isolate_data) override;
+  void RegisterIsolate(v8::Isolate* isolate, uv_loop_t* loop) override;
+  void UnregisterIsolate(v8::Isolate* isolate) override;
 
   std::shared_ptr<v8::TaskRunner> GetForegroundTaskRunner(
       v8::Isolate* isolate) override;

--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -85,12 +85,15 @@ class NodeTestFixture : public ::testing::Test {
   }
 
   virtual void SetUp() {
-    isolate_ = v8::Isolate::New(params);
+    isolate_ = v8::Isolate::Allocate();
     CHECK_NE(isolate_, nullptr);
+    platform->RegisterIsolate(isolate_, &current_loop);
+    v8::Isolate::Initialize(isolate_, params);
   }
 
   virtual void TearDown() {
     isolate_->Dispose();
+    platform->UnregisterIsolate(isolate_);
     isolate_ = nullptr;
   }
 };


### PR DESCRIPTION
In V8 we recently introduced a new API to post tasks (e.g. compilation
tasks). To post a task, the new API requires to acquire a TaskRunner
from the platform first, and then use the TaskRunner to post tasks.

With this PR we allow V8 to acquire TaskRunners already during the
initialization of the isolate. The idea of the PR is to first allocate 
an uninitialized isolate, then to initialize the PerIsolateData with the
TaskRunner on the isolate, and finally to initialize the isolate itself.

The same approach has already been implemented in Chrome.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
