### PR TITLE
tools: Remove lldbinit file from install script

### DIFF
--- a/tools/install.py
+++ b/tools/install.py
@@ -144,7 +144,6 @@ def files(action):
   action(['src/node.stp'], 'share/systemtap/tapset/')
 
   action(['deps/v8/tools/gdbinit'], 'share/doc/node/')
-  action(['deps/v8/tools/lldbinit'], 'share/doc/node/')
   action(['deps/v8/tools/lldb_commands.py'], 'share/doc/node/')
 
   if 'freebsd' in sys.platform or 'openbsd' in sys.platform:


### PR DESCRIPTION
In v8 we want to remove the lldbinit file (https://crrev.com/c/1127892).
In order to not brake node.js, we need to remove it here first.