### PR TITLE
v8: Remove deprecated non-Isolate API calls

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -309,7 +309,7 @@ void Environment::PrintSyncTrace() const {
           uv_os_getpid());
 
   for (int i = 0; i < stack->GetFrameCount() - 1; i++) {
-    Local<StackFrame> stack_frame = stack->GetFrame(i);
+    Local<StackFrame> stack_frame = stack->GetFrame(isolate(), i);
     node::Utf8Value fn_name_s(isolate(), stack_frame->GetFunctionName());
     node::Utf8Value script_name(isolate(), stack_frame->GetScriptName());
     const int line_number = stack_frame->GetLineNumber();

--- a/src/exceptions.cc
+++ b/src/exceptions.cc
@@ -26,31 +26,31 @@ Local<Value> ErrnoException(Isolate* isolate,
   Environment* env = Environment::GetCurrent(isolate);
 
   Local<Value> e;
-  Local<String> estring = OneByteString(env->isolate(), errno_string(errorno));
+  Local<String> estring = OneByteString(isolate, errno_string(errorno));
   if (msg == nullptr || msg[0] == '\0') {
     msg = strerror(errorno);
   }
-  Local<String> message = OneByteString(env->isolate(), msg);
+  Local<String> message = OneByteString(isolate, msg);
 
   Local<String> cons =
-      String::Concat(estring, FIXED_ONE_BYTE_STRING(env->isolate(), ", "));
-  cons = String::Concat(cons, message);
+      String::Concat(isolate, estring, FIXED_ONE_BYTE_STRING(isolate, ", "));
+  cons = String::Concat(isolate, cons, message);
 
   Local<String> path_string;
   if (path != nullptr) {
     // FIXME(bnoordhuis) It's questionable to interpret the file path as UTF-8.
-    path_string = String::NewFromUtf8(env->isolate(), path);
+    path_string = String::NewFromUtf8(isolate, path);
   }
 
   if (path_string.IsEmpty() == false) {
-    cons = String::Concat(cons, FIXED_ONE_BYTE_STRING(env->isolate(), " '"));
-    cons = String::Concat(cons, path_string);
-    cons = String::Concat(cons, FIXED_ONE_BYTE_STRING(env->isolate(), "'"));
+    cons = String::Concat(isolate, cons, FIXED_ONE_BYTE_STRING(isolate, " '"));
+    cons = String::Concat(isolate, cons, path_string);
+    cons = String::Concat(isolate, cons, FIXED_ONE_BYTE_STRING(isolate, "'"));
   }
   e = Exception::Error(cons);
 
   Local<Object> obj = e.As<Object>();
-  obj->Set(env->errno_string(), Integer::New(env->isolate(), errorno));
+  obj->Set(env->errno_string(), Integer::New(isolate, errorno));
   obj->Set(env->code_string(), estring);
 
   if (path_string.IsEmpty() == false) {
@@ -58,7 +58,7 @@ Local<Value> ErrnoException(Isolate* isolate,
   }
 
   if (syscall != nullptr) {
-    obj->Set(env->syscall_string(), OneByteString(env->isolate(), syscall));
+    obj->Set(env->syscall_string(), OneByteString(isolate, syscall));
   }
 
   return e;
@@ -67,7 +67,7 @@ Local<Value> ErrnoException(Isolate* isolate,
 static Local<String> StringFromPath(Isolate* isolate, const char* path) {
 #ifdef _WIN32
   if (strncmp(path, "\\\\?\\UNC\\", 8) == 0) {
-    return String::Concat(FIXED_ONE_BYTE_STRING(isolate, "\\\\"),
+    return String::Concat(isolate, FIXED_ONE_BYTE_STRING(isolate, "\\\\"),
                           String::NewFromUtf8(isolate, path + 8));
   } else if (strncmp(path, "\\\\?\\", 4) == 0) {
     return String::NewFromUtf8(isolate, path + 4);
@@ -104,25 +104,31 @@ Local<Value> UVException(Isolate* isolate,
   Local<String> js_dest;
 
   Local<String> js_msg = js_code;
-  js_msg = String::Concat(js_msg, FIXED_ONE_BYTE_STRING(isolate, ": "));
-  js_msg = String::Concat(js_msg, OneByteString(isolate, msg));
-  js_msg = String::Concat(js_msg, FIXED_ONE_BYTE_STRING(isolate, ", "));
-  js_msg = String::Concat(js_msg, js_syscall);
+  js_msg =
+      String::Concat(isolate, js_msg, FIXED_ONE_BYTE_STRING(isolate, ": "));
+  js_msg = String::Concat(isolate, js_msg, OneByteString(isolate, msg));
+  js_msg =
+      String::Concat(isolate, js_msg, FIXED_ONE_BYTE_STRING(isolate, ", "));
+  js_msg = String::Concat(isolate, js_msg, js_syscall);
 
   if (path != nullptr) {
     js_path = StringFromPath(isolate, path);
 
-    js_msg = String::Concat(js_msg, FIXED_ONE_BYTE_STRING(isolate, " '"));
-    js_msg = String::Concat(js_msg, js_path);
-    js_msg = String::Concat(js_msg, FIXED_ONE_BYTE_STRING(isolate, "'"));
+    js_msg =
+        String::Concat(isolate, js_msg, FIXED_ONE_BYTE_STRING(isolate, " '"));
+    js_msg = String::Concat(isolate, js_msg, js_path);
+    js_msg =
+        String::Concat(isolate, js_msg, FIXED_ONE_BYTE_STRING(isolate, "'"));
   }
 
   if (dest != nullptr) {
     js_dest = StringFromPath(isolate, dest);
 
-    js_msg = String::Concat(js_msg, FIXED_ONE_BYTE_STRING(isolate, " -> '"));
-    js_msg = String::Concat(js_msg, js_dest);
-    js_msg = String::Concat(js_msg, FIXED_ONE_BYTE_STRING(isolate, "'"));
+    js_msg = String::Concat(isolate, js_msg,
+                            FIXED_ONE_BYTE_STRING(isolate, " -> '"));
+    js_msg = String::Concat(isolate, js_msg, js_dest);
+    js_msg =
+        String::Concat(isolate, js_msg, FIXED_ONE_BYTE_STRING(isolate, "'"));
   }
 
   Local<Object> e = Exception::Error(js_msg)->ToObject(isolate);
@@ -177,15 +183,15 @@ Local<Value> WinapiErrnoException(Isolate* isolate,
   if (!msg || !msg[0]) {
     msg = winapi_strerror(errorno, &must_free);
   }
-  Local<String> message = OneByteString(env->isolate(), msg);
+  Local<String> message = OneByteString(isolate, msg);
 
   if (path) {
     Local<String> cons1 =
-        String::Concat(message, FIXED_ONE_BYTE_STRING(isolate, " '"));
+        String::Concat(isolate, message, FIXED_ONE_BYTE_STRING(isolate, " '"));
     Local<String> cons2 =
-        String::Concat(cons1, String::NewFromUtf8(isolate, path));
+        String::Concat(isolate, cons1, String::NewFromUtf8(isolate, path));
     Local<String> cons3 =
-        String::Concat(cons2, FIXED_ONE_BYTE_STRING(isolate, "'"));
+        String::Concat(isolate, cons2, FIXED_ONE_BYTE_STRING(isolate, "'"));
     e = Exception::Error(cons3);
   } else {
     e = Exception::Error(message);

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -446,9 +446,8 @@ class NodeInspectorClient : public V8InspectorClient {
 
     Local<v8::StackTrace> stack_trace = message->GetStackTrace();
 
-    if (!stack_trace.IsEmpty() &&
-        stack_trace->GetFrameCount() > 0 &&
-        script_id == stack_trace->GetFrame(0)->GetScriptId()) {
+    if (!stack_trace.IsEmpty() && stack_trace->GetFrameCount() > 0 &&
+        script_id == stack_trace->GetFrame(env_->isolate(), 0)->GetScriptId()) {
       script_id = 0;
     }
 

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -234,8 +234,8 @@ void Open(const FunctionCallbackInfo<Value>& args) {
   Agent* agent = env->inspector_agent();
   bool wait_for_connect = false;
 
-  if (args.Length() > 0 && args[0]->IsUint32()) {
-    uint32_t port = args[0]->Uint32Value();
+  uint32_t port;
+  if (args.Length() > 0 && args[0]->Uint32Value(env->context()).To(&port)) {
     agent->options().set_port(static_cast<int>(port));
   }
 

--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -154,7 +154,7 @@ void JSStream::Finish(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsObject());
   Wrap* w = static_cast<Wrap*>(StreamReq::FromObject(args[0].As<Object>()));
 
-  w->Done(args[1]->Int32Value());
+  w->Done(args[1]->Int32Value(args.Holder()->CreationContext()).FromMaybe(0));
 }
 
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -1127,7 +1127,7 @@ static void Exit(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   WaitForInspectorDisconnect(env);
   v8_platform.StopTracingAgent();
-  env->Exit(args[0]->Int32Value());
+  env->Exit(args[0]->Int32Value(env->context()).FromMaybe(0));
 }
 
 extern "C" void node_module_register(void* m) {
@@ -1917,7 +1917,8 @@ static void DebugPortSetter(Local<Name> property,
                             Local<Value> value,
                             const PropertyCallbackInfo<void>& info) {
   Mutex::ScopedLock lock(process_mutex);
-  debug_options.set_port(value->Int32Value());
+  debug_options.set_port(
+      value->Int32Value(info.Holder()->CreationContext()).FromMaybe(0));
 }
 
 
@@ -3002,7 +3003,7 @@ void DebugProcess(const FunctionCallbackInfo<Value>& args) {
   pid_t pid;
   int r;
 
-  pid = args[0]->IntegerValue();
+  pid = args[0]->IntegerValue(env->context()).FromMaybe(0);
   r = kill(pid, SIGUSR1);
   if (r != 0) {
     return env->ThrowErrnoException(errno, "kill");

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -1785,13 +1785,15 @@ static napi_status set_error_code(napi_env env,
     if (!maybe_name.IsEmpty()) {
       v8::Local<v8::Value> name = maybe_name.ToLocalChecked();
       if (name->IsString()) {
-        name_string = v8::String::Concat(name_string, name.As<v8::String>());
+        name_string =
+            v8::String::Concat(isolate, name_string, name.As<v8::String>());
       }
     }
-    name_string = v8::String::Concat(name_string,
+    name_string = v8::String::Concat(isolate, name_string,
                                      FIXED_ONE_BYTE_STRING(isolate, " ["));
-    name_string = v8::String::Concat(name_string, code_value.As<v8::String>());
-    name_string = v8::String::Concat(name_string,
+    name_string =
+        v8::String::Concat(isolate, name_string, code_value.As<v8::String>());
+    name_string = v8::String::Concat(isolate, name_string,
                                      FIXED_ONE_BYTE_STRING(isolate, "]"));
 
     set_maybe = err_object->Set(context, name_key, name_string);
@@ -2240,8 +2242,8 @@ napi_status napi_get_value_string_latin1(napi_env env,
     *result = val.As<v8::String>()->Length();
   } else {
     int copied = val.As<v8::String>()->WriteOneByte(
-      reinterpret_cast<uint8_t*>(buf), 0, bufsize - 1,
-      v8::String::NO_NULL_TERMINATION);
+        env->isolate, reinterpret_cast<uint8_t*>(buf), 0, bufsize - 1,
+        v8::String::NO_NULL_TERMINATION);
 
     buf[copied] = '\0';
     if (result != nullptr) {
@@ -2273,11 +2275,11 @@ napi_status napi_get_value_string_utf8(napi_env env,
 
   if (!buf) {
     CHECK_ARG(env, result);
-    *result = val.As<v8::String>()->Utf8Length();
+    *result = val.As<v8::String>()->Utf8Length(env->isolate);
   } else {
     int copied = val.As<v8::String>()->WriteUtf8(
-      buf, bufsize - 1, nullptr, v8::String::REPLACE_INVALID_UTF8 |
-      v8::String::NO_NULL_TERMINATION);
+        env->isolate, buf, bufsize - 1, nullptr,
+        v8::String::REPLACE_INVALID_UTF8 | v8::String::NO_NULL_TERMINATION);
 
     buf[copied] = '\0';
     if (result != nullptr) {
@@ -2313,8 +2315,8 @@ napi_status napi_get_value_string_utf16(napi_env env,
     *result = val.As<v8::String>()->Length();
   } else {
     int copied = val.As<v8::String>()->Write(
-      reinterpret_cast<uint16_t*>(buf), 0, bufsize - 1,
-      v8::String::NO_NULL_TERMINATION);
+        env->isolate, reinterpret_cast<uint16_t*>(buf), 0, bufsize - 1,
+        v8::String::NO_NULL_TERMINATION);
 
     buf[copied] = '\0';
     if (result != nullptr) {

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -45,11 +45,11 @@
     if (!(r)) return node::THROW_ERR_INDEX_OUT_OF_RANGE(env);               \
   } while (0)
 
-#define SLICE_START_END(start_arg, end_arg, end_max)                        \
+#define SLICE_START_END(env, start_arg, end_arg, end_max)                   \
   size_t start;                                                             \
   size_t end;                                                               \
-  THROW_AND_RETURN_IF_OOB(ParseArrayIndex(start_arg, 0, &start));           \
-  THROW_AND_RETURN_IF_OOB(ParseArrayIndex(end_arg, end_max, &end));         \
+  THROW_AND_RETURN_IF_OOB(ParseArrayIndex(env, start_arg, 0, &start));      \
+  THROW_AND_RETURN_IF_OOB(ParseArrayIndex(env, end_arg, end_max, &end));    \
   if (end < start) end = start;                                             \
   THROW_AND_RETURN_IF_OOB(end <= end_max);                                  \
   size_t length = end - start;
@@ -164,7 +164,8 @@ void CallbackInfo::WeakCallback(Isolate* isolate) {
 
 
 // Parse index for external array data.
-inline MUST_USE_RESULT bool ParseArrayIndex(Local<Value> arg,
+inline MUST_USE_RESULT bool ParseArrayIndex(Environment* env,
+                                            Local<Value> arg,
                                             size_t def,
                                             size_t* ret) {
   if (arg->IsUndefined()) {
@@ -172,9 +173,8 @@ inline MUST_USE_RESULT bool ParseArrayIndex(Local<Value> arg,
     return true;
   }
 
-  int64_t tmp_i = arg->IntegerValue();
-
-  if (tmp_i < 0)
+  int64_t tmp_i;
+  if (!arg->IntegerValue(env->context()).To(&tmp_i) || tmp_i < 0)
     return false;
 
   // Check that the result fits in a size_t.
@@ -446,7 +446,7 @@ void StringSlice(const FunctionCallbackInfo<Value>& args) {
   if (ts_obj_length == 0)
     return args.GetReturnValue().SetEmptyString();
 
-  SLICE_START_END(args[0], args[1], ts_obj_length)
+  SLICE_START_END(env, args[0], args[1], ts_obj_length)
 
   Local<Value> error;
   MaybeLocal<Value> ret =
@@ -475,7 +475,7 @@ void StringSlice<UCS2>(const FunctionCallbackInfo<Value>& args) {
   if (ts_obj_length == 0)
     return args.GetReturnValue().SetEmptyString();
 
-  SLICE_START_END(args[0], args[1], ts_obj_length)
+  SLICE_START_END(env, args[0], args[1], ts_obj_length)
   length /= 2;
 
   const char* data = ts_obj_data + start;
@@ -538,9 +538,10 @@ void Copy(const FunctionCallbackInfo<Value> &args) {
   size_t source_start;
   size_t source_end;
 
-  THROW_AND_RETURN_IF_OOB(ParseArrayIndex(args[2], 0, &target_start));
-  THROW_AND_RETURN_IF_OOB(ParseArrayIndex(args[3], 0, &source_start));
-  THROW_AND_RETURN_IF_OOB(ParseArrayIndex(args[4], ts_obj_length, &source_end));
+  THROW_AND_RETURN_IF_OOB(ParseArrayIndex(env, args[2], 0, &target_start));
+  THROW_AND_RETURN_IF_OOB(ParseArrayIndex(env, args[3], 0, &source_start));
+  THROW_AND_RETURN_IF_OOB(
+      ParseArrayIndex(env, args[4], ts_obj_length, &source_end));
 
   // Copy 0 bytes; we're done
   if (target_start >= target_length || source_start >= source_end)
@@ -567,8 +568,8 @@ void Fill(const FunctionCallbackInfo<Value>& args) {
   THROW_AND_RETURN_UNLESS_BUFFER(env, args[0]);
   SPREAD_BUFFER_ARG(args[0], ts_obj);
 
-  size_t start = args[2]->Uint32Value();
-  size_t end = args[3]->Uint32Value();
+  size_t start = args[2]->Uint32Value(env->context()).FromMaybe(0);
+  size_t end = args[3]->Uint32Value(env->context()).FromMaybe(0);
   size_t fill_length = end - start;
   Local<String> str_obj;
   size_t str_length;
@@ -588,7 +589,7 @@ void Fill(const FunctionCallbackInfo<Value>& args) {
 
   // Then coerce everything that's not a string.
   if (!args[1]->IsString()) {
-    int value = args[1]->Uint32Value() & 255;
+    int value = args[1]->Uint32Value(env->context()).FromMaybe(0) & 255;
     memset(ts_obj_data + start, value, fill_length);
     return;
   }
@@ -599,7 +600,7 @@ void Fill(const FunctionCallbackInfo<Value>& args) {
   // Can't use StringBytes::Write() in all cases. For example if attempting
   // to write a two byte character into a one byte Buffer.
   if (enc == UTF8) {
-    str_length = str_obj->Utf8Length();
+    str_length = str_obj->Utf8Length(env->isolate());
     node::Utf8Value str(env->isolate(), args[1]);
     memcpy(ts_obj_data + start, *str, MIN(str_length, fill_length));
 
@@ -666,14 +667,14 @@ void StringWrite(const FunctionCallbackInfo<Value>& args) {
   size_t offset;
   size_t max_length;
 
-  THROW_AND_RETURN_IF_OOB(ParseArrayIndex(args[1], 0, &offset));
+  THROW_AND_RETURN_IF_OOB(ParseArrayIndex(env, args[1], 0, &offset));
   if (offset > ts_obj_length) {
     return node::THROW_ERR_BUFFER_OUT_OF_BOUNDS(
         env, "\"offset\" is outside of buffer bounds");
   }
 
-  THROW_AND_RETURN_IF_OOB(ParseArrayIndex(args[2], ts_obj_length - offset,
-                                          &max_length));
+  THROW_AND_RETURN_IF_OOB(
+      ParseArrayIndex(env, args[2], ts_obj_length - offset, &max_length));
 
   max_length = MIN(ts_obj_length - offset, max_length);
 
@@ -693,7 +694,8 @@ void ByteLengthUtf8(const FunctionCallbackInfo<Value> &args) {
   CHECK(args[0]->IsString());
 
   // Fast case: avoid StringBytes on UTF8 string. Jump to v8.
-  args.GetReturnValue().Set(args[0].As<String>()->Utf8Length());
+  args.GetReturnValue().Set(
+      args[0].As<String>()->Utf8Length(args.GetIsolate()));
 }
 
 // Normalize val to be an integer in the range of [1, -1] since
@@ -726,10 +728,12 @@ void CompareOffset(const FunctionCallbackInfo<Value> &args) {
   size_t source_end;
   size_t target_end;
 
-  THROW_AND_RETURN_IF_OOB(ParseArrayIndex(args[2], 0, &target_start));
-  THROW_AND_RETURN_IF_OOB(ParseArrayIndex(args[3], 0, &source_start));
-  THROW_AND_RETURN_IF_OOB(ParseArrayIndex(args[4], target_length, &target_end));
-  THROW_AND_RETURN_IF_OOB(ParseArrayIndex(args[5], ts_obj_length, &source_end));
+  THROW_AND_RETURN_IF_OOB(ParseArrayIndex(env, args[2], 0, &target_start));
+  THROW_AND_RETURN_IF_OOB(ParseArrayIndex(env, args[3], 0, &source_start));
+  THROW_AND_RETURN_IF_OOB(
+      ParseArrayIndex(env, args[4], target_length, &target_end));
+  THROW_AND_RETURN_IF_OOB(
+      ParseArrayIndex(env, args[5], ts_obj_length, &source_end));
 
   if (source_start > ts_obj_length)
     return node::THROW_ERR_INDEX_OUT_OF_RANGE(env);
@@ -815,11 +819,12 @@ void IndexOfString(const FunctionCallbackInfo<Value>& args) {
                                     args[3],
                                     UTF8);
 
-  THROW_AND_RETURN_UNLESS_BUFFER(Environment::GetCurrent(args), args[0]);
+  Environment* env = Environment::GetCurrent(args);
+  THROW_AND_RETURN_UNLESS_BUFFER(env, args[0]);
   SPREAD_BUFFER_ARG(args[0], ts_obj);
 
   Local<String> needle = args[1].As<String>();
-  int64_t offset_i64 = args[2]->IntegerValue();
+  int64_t offset_i64 = args[2]->IntegerValue(env->context()).FromMaybe(0);
   bool is_forward = args[4]->IsTrue();
 
   const char* haystack = ts_obj_data;
@@ -906,8 +911,8 @@ void IndexOfString(const FunctionCallbackInfo<Value>& args) {
     if (needle_data == nullptr) {
       return args.GetReturnValue().Set(-1);
     }
-    needle->WriteOneByte(
-        needle_data, 0, needle_length, String::NO_NULL_TERMINATION);
+    needle->WriteOneByte(env->isolate(), needle_data, 0, needle_length,
+                         String::NO_NULL_TERMINATION);
 
     result = SearchString(reinterpret_cast<const uint8_t*>(haystack),
                           haystack_length,
@@ -931,11 +936,12 @@ void IndexOfBuffer(const FunctionCallbackInfo<Value>& args) {
                                     args[3],
                                     UTF8);
 
-  THROW_AND_RETURN_UNLESS_BUFFER(Environment::GetCurrent(args), args[0]);
-  THROW_AND_RETURN_UNLESS_BUFFER(Environment::GetCurrent(args), args[1]);
+  Environment* env = Environment::GetCurrent(args);
+  THROW_AND_RETURN_UNLESS_BUFFER(env, args[0]);
+  THROW_AND_RETURN_UNLESS_BUFFER(env, args[1]);
   SPREAD_BUFFER_ARG(args[0], ts_obj);
   SPREAD_BUFFER_ARG(args[1], buf);
-  int64_t offset_i64 = args[2]->IntegerValue();
+  int64_t offset_i64 = args[2]->IntegerValue(env->context()).FromMaybe(0);
   bool is_forward = args[4]->IsTrue();
 
   const char* haystack = ts_obj_data;
@@ -1001,11 +1007,12 @@ void IndexOfNumber(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[2]->IsNumber());
   CHECK(args[3]->IsBoolean());
 
-  THROW_AND_RETURN_UNLESS_BUFFER(Environment::GetCurrent(args), args[0]);
+  Environment* env = Environment::GetCurrent(args);
+  THROW_AND_RETURN_UNLESS_BUFFER(env, args[0]);
   SPREAD_BUFFER_ARG(args[0], ts_obj);
 
-  uint32_t needle = args[1]->Uint32Value();
-  int64_t offset_i64 = args[2]->IntegerValue();
+  uint32_t needle = args[1]->Uint32Value(env->context()).FromMaybe(0);
+  int64_t offset_i64 = args[2]->IntegerValue(env->context()).FromMaybe(0);
   bool is_forward = args[3]->IsTrue();
 
   int64_t opt_offset = IndexOfOffset(ts_obj_length, offset_i64, 1, is_forward);
@@ -1062,10 +1069,10 @@ static void EncodeUtf8String(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsString());
 
   Local<String> str = args[0].As<String>();
-  size_t length = str->Utf8Length();
+  size_t length = str->Utf8Length(env->isolate());
   char* data = node::UncheckedMalloc(length);
-  str->WriteUtf8(data,
-                 -1,   // We are certain that `data` is sufficiently large
+  str->WriteUtf8(env->isolate(), data,
+                 -1,  // We are certain that `data` is sufficiently large
                  nullptr,
                  String::NO_NULL_TERMINATION | String::REPLACE_INVALID_UTF8);
   auto array_buf = ArrayBuffer::New(env->isolate(), data, length,

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -864,8 +864,9 @@ class ContextifyScript : public BaseObject {
     }
 
     Local<String> decorated_stack = String::Concat(
-        String::Concat(arrow.As<String>(),
-          FIXED_ONE_BYTE_STRING(env->isolate(), "\n")),
+        env->isolate(),
+        String::Concat(env->isolate(), arrow.As<String>(),
+                       FIXED_ONE_BYTE_STRING(env->isolate(), "\n")),
         stack.As<String>());
     err_obj->Set(env->stack_string(), decorated_stack);
     err_obj->SetPrivate(

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -381,10 +381,9 @@ Headers::Headers(Isolate* isolate,
   nghttp2_nv* const nva = reinterpret_cast<nghttp2_nv*>(start);
 
   CHECK_LE(header_contents + header_string_len, *buf_ + buf_.length());
-  CHECK_EQ(header_string.As<String>()
-              ->WriteOneByte(reinterpret_cast<uint8_t*>(header_contents),
-                             0, header_string_len,
-                             String::NO_NULL_TERMINATION),
+  CHECK_EQ(header_string.As<String>()->WriteOneByte(
+               isolate, reinterpret_cast<uint8_t*>(header_contents), 0,
+               header_string_len, String::NO_NULL_TERMINATION),
            header_string_len);
 
   size_t n = 0;
@@ -2629,8 +2628,8 @@ void Http2Session::AltSvc(const FunctionCallbackInfo<Value>& args) {
 
   MaybeStackBuffer<uint8_t> origin(origin_len);
   MaybeStackBuffer<uint8_t> value(value_len);
-  origin_str->WriteOneByte(*origin);
-  value_str->WriteOneByte(*value);
+  origin_str->WriteOneByte(env->isolate(), *origin);
+  value_str->WriteOneByte(env->isolate(), *value);
 
   session->AltSvc(id, *origin, origin_len, *value, value_len);
 }

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -291,7 +291,9 @@ class Parser : public AsyncWrap, public StreamListener {
       return -1;
     }
 
-    return head_response.ToLocalChecked()->IntegerValue();
+    return head_response.ToLocalChecked()
+        ->IntegerValue(env()->context())
+        .FromMaybe(0);
   }
 
 
@@ -359,8 +361,8 @@ class Parser : public AsyncWrap, public StreamListener {
 
   static void New(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args);
-    http_parser_type type =
-        static_cast<http_parser_type>(args[0]->Int32Value());
+    http_parser_type type = static_cast<http_parser_type>(
+        args[0]->Int32Value(env->context()).FromMaybe(0));
     CHECK(type == HTTP_REQUEST || type == HTTP_RESPONSE);
     new Parser(env, args.This(), type);
   }
@@ -456,8 +458,8 @@ class Parser : public AsyncWrap, public StreamListener {
   static void Reinitialize(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args);
 
-    http_parser_type type =
-        static_cast<http_parser_type>(args[0]->Int32Value());
+    http_parser_type type = static_cast<http_parser_type>(
+        args[0]->Int32Value(env->context()).FromMaybe(0));
 
     CHECK(type == HTTP_REQUEST || type == HTTP_RESPONSE);
     Parser* parser;

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -496,7 +496,8 @@ void Transcode(const FunctionCallbackInfo<Value>&args) {
 
 void ICUErrorName(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-  UErrorCode status = static_cast<UErrorCode>(args[0]->Int32Value());
+  UErrorCode status =
+      static_cast<UErrorCode>(args[0]->Int32Value(env->context()).FromMaybe(0));
   args.GetReturnValue().Set(
       String::NewFromUtf8(env->isolate(),
                           u_errorName(status),
@@ -809,12 +810,14 @@ static void GetStringWidth(const FunctionCallbackInfo<Value>& args) {
   if (args.Length() < 1)
     return;
 
-  bool ambiguous_as_full_width = args[1]->BooleanValue();
-  bool expand_emoji_sequence = args[2]->BooleanValue();
+  bool ambiguous_as_full_width =
+      args[1]->BooleanValue(env->context()).FromMaybe(false);
+  bool expand_emoji_sequence =
+      args[2]->BooleanValue(env->context()).FromMaybe(false);
 
   if (args[0]->IsNumber()) {
     args.GetReturnValue().Set(
-        GetColumnWidth(args[0]->Uint32Value(),
+        GetColumnWidth(args[0]->Uint32Value(env->context()).FromMaybe(0),
                        ambiguous_as_full_width));
     return;
   }

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -155,7 +155,8 @@ class ZCtx : public AsyncWrap, public ThreadPoolWork {
 
     CHECK_EQ(false, args[0]->IsUndefined() && "must provide flush value");
 
-    unsigned int flush = args[0]->Uint32Value();
+    unsigned int flush =
+        args[0]->Uint32Value(ctx->env()->context()).FromMaybe(0);
 
     if (flush != Z_NO_FLUSH &&
         flush != Z_PARTIAL_FLUSH &&
@@ -182,8 +183,8 @@ class ZCtx : public AsyncWrap, public ThreadPoolWork {
       CHECK(Buffer::HasInstance(args[1]));
       Local<Object> in_buf;
       in_buf = args[1]->ToObject(env->context()).ToLocalChecked();
-      in_off = args[2]->Uint32Value();
-      in_len = args[3]->Uint32Value();
+      in_off = args[2]->Uint32Value(env->context()).FromMaybe(0);
+      in_len = args[3]->Uint32Value(env->context()).FromMaybe(0);
 
       CHECK(Buffer::IsWithinBounds(in_off, in_len, Buffer::Length(in_buf)));
       in = reinterpret_cast<Bytef *>(Buffer::Data(in_buf) + in_off);
@@ -191,8 +192,8 @@ class ZCtx : public AsyncWrap, public ThreadPoolWork {
 
     CHECK(Buffer::HasInstance(args[4]));
     Local<Object> out_buf = args[4]->ToObject(env->context()).ToLocalChecked();
-    out_off = args[5]->Uint32Value();
-    out_len = args[6]->Uint32Value();
+    out_off = args[5]->Uint32Value(env->context()).FromMaybe(0);
+    out_len = args[6]->Uint32Value(env->context()).FromMaybe(0);
     CHECK(Buffer::IsWithinBounds(out_off, out_len, Buffer::Length(out_buf)));
     out = reinterpret_cast<Bytef *>(Buffer::Data(out_buf) + out_off);
 
@@ -415,7 +416,8 @@ class ZCtx : public AsyncWrap, public ThreadPoolWork {
   static void New(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args);
     CHECK(args[0]->IsInt32());
-    node_zlib_mode mode = static_cast<node_zlib_mode>(args[0]->Int32Value());
+    node_zlib_mode mode = static_cast<node_zlib_mode>(
+        args[0]->Int32Value(env->context()).FromMaybe(0));
     new ZCtx(env, args.This(), mode);
   }
 
@@ -441,7 +443,7 @@ class ZCtx : public AsyncWrap, public ThreadPoolWork {
     // windowBits is special. On the compression side, 0 is an invalid value.
     // But on the decompression side, a value of 0 for windowBits tells zlib
     // to use the window size in the zlib header of the compressed stream.
-    int windowBits = args[0]->Uint32Value();
+    int windowBits = args[0]->Uint32Value(ctx->env()->context()).FromMaybe(0);
     if (!((windowBits == 0) &&
           (ctx->mode_ == INFLATE ||
            ctx->mode_ == GUNZIP ||
@@ -450,15 +452,15 @@ class ZCtx : public AsyncWrap, public ThreadPoolWork {
              windowBits <= Z_MAX_WINDOWBITS) && "invalid windowBits");
     }
 
-    int level = args[1]->Int32Value();
+    int level = args[1]->Int32Value(ctx->env()->context()).FromMaybe(0);
     CHECK((level >= Z_MIN_LEVEL && level <= Z_MAX_LEVEL) &&
       "invalid compression level");
 
-    int memLevel = args[2]->Uint32Value();
+    int memLevel = args[2]->Uint32Value(ctx->env()->context()).FromMaybe(0);
     CHECK((memLevel >= Z_MIN_MEMLEVEL && memLevel <= Z_MAX_MEMLEVEL) &&
       "invalid memlevel");
 
-    int strategy = args[3]->Uint32Value();
+    int strategy = args[3]->Uint32Value(ctx->env()->context()).FromMaybe(0);
     CHECK((strategy == Z_FILTERED ||
            strategy == Z_HUFFMAN_ONLY ||
            strategy == Z_RLE ||
@@ -496,7 +498,8 @@ class ZCtx : public AsyncWrap, public ThreadPoolWork {
     CHECK(args.Length() == 2 && "params(level, strategy)");
     ZCtx* ctx;
     ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Holder());
-    Params(ctx, args[0]->Int32Value(), args[1]->Int32Value());
+    Params(ctx, args[0]->Int32Value(ctx->env()->context()).FromMaybe(0),
+           args[1]->Int32Value(ctx->env()->context()).FromMaybe(0));
   }
 
   static void Reset(const FunctionCallbackInfo<Value> &args) {

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -178,7 +178,7 @@ void PipeWrap::Bind(const FunctionCallbackInfo<Value>& args) {
 void PipeWrap::SetPendingInstances(const FunctionCallbackInfo<Value>& args) {
   PipeWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
-  int instances = args[0]->Int32Value();
+  int instances = args[0]->Int32Value(wrap->env()->context()).FromMaybe(0);
   uv_pipe_pending_instances(&wrap->handle_, instances);
 }
 #endif
@@ -198,7 +198,7 @@ void PipeWrap::Fchmod(const v8::FunctionCallbackInfo<v8::Value>& args) {
 void PipeWrap::Listen(const FunctionCallbackInfo<Value>& args) {
   PipeWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
-  int backlog = args[0]->Int32Value();
+  int backlog = args[0]->Int32Value(wrap->env()->context()).FromMaybe(0);
   int err = uv_listen(reinterpret_cast<uv_stream_t*>(&wrap->handle_),
                       backlog,
                       OnConnection);
@@ -212,7 +212,7 @@ void PipeWrap::Open(const FunctionCallbackInfo<Value>& args) {
   PipeWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
 
-  int fd = args[0]->Int32Value();
+  int fd = args[0]->Int32Value(wrap->env()->context()).FromMaybe(0);
 
   int err = uv_pipe_open(&wrap->handle_, fd);
   wrap->set_fd(fd);

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -109,9 +109,10 @@ class ProcessWrap : public HandleWrap {
       Local<Value> type =
           stdio->Get(context, env->type_string()).ToLocalChecked();
 
-      if (type->Equals(env->ignore_string())) {
+      if (type->Equals(env->context(), env->ignore_string()).FromMaybe(false)) {
         options->stdio[i].flags = UV_IGNORE;
-      } else if (type->Equals(env->pipe_string())) {
+      } else if (type->Equals(env->context(), env->pipe_string())
+                     .FromMaybe(false)) {
         options->stdio[i].flags = static_cast<uv_stdio_flags>(
             UV_CREATE_PIPE | UV_READABLE_PIPE | UV_WRITABLE_PIPE);
         Local<String> handle_key = env->handle_string();
@@ -121,7 +122,8 @@ class ProcessWrap : public HandleWrap {
         options->stdio[i].data.stream =
             reinterpret_cast<uv_stream_t*>(
                 Unwrap<PipeWrap>(handle)->UVHandle());
-      } else if (type->Equals(env->wrap_string())) {
+      } else if (type->Equals(env->context(), env->wrap_string())
+                     .FromMaybe(false)) {
         Local<String> handle_key = env->handle_string();
         Local<Object> handle =
             stdio->Get(context, handle_key).ToLocalChecked().As<Object>();
@@ -132,8 +134,10 @@ class ProcessWrap : public HandleWrap {
         options->stdio[i].data.stream = stream;
       } else {
         Local<String> fd_key = env->fd_string();
-        int fd = static_cast<int>(
-            stdio->Get(context, fd_key).ToLocalChecked()->IntegerValue());
+        int fd = static_cast<int>(stdio->Get(context, fd_key)
+                                      .ToLocalChecked()
+                                      ->IntegerValue(env->context())
+                                      .FromMaybe(0));
         options->stdio[i].flags = UV_INHERIT_FD;
         options->stdio[i].data.fd = fd;
       }

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -86,7 +86,7 @@ class SignalWrap : public HandleWrap {
   static void Start(const FunctionCallbackInfo<Value>& args) {
     SignalWrap* wrap;
     ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
-    int signum = args[0]->Int32Value();
+    int signum = args[0]->Int32Value(wrap->env()->context()).FromMaybe(0);
 #if defined(__POSIX__) && HAVE_INSPECTOR
     if (signum == SIGPROF) {
       Environment* env = Environment::GetCurrent(args);

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -257,8 +257,8 @@ static size_t hex_decode(char* buf,
   return i;
 }
 
-
-size_t StringBytes::WriteUCS2(char* buf,
+size_t StringBytes::WriteUCS2(Isolate* isolate,
+                              char* buf,
                               size_t buflen,
                               Local<String> str,
                               int flags,
@@ -269,7 +269,7 @@ size_t StringBytes::WriteUCS2(char* buf,
   size_t nchars;
   size_t alignment = reinterpret_cast<uintptr_t>(dst) % sizeof(*dst);
   if (alignment == 0) {
-    nchars = str->Write(dst, 0, max_chars, flags);
+    nchars = str->Write(isolate, dst, 0, max_chars, flags);
     *chars_written = nchars;
     return nchars * sizeof(*dst);
   }
@@ -279,14 +279,15 @@ size_t StringBytes::WriteUCS2(char* buf,
   CHECK_EQ(reinterpret_cast<uintptr_t>(aligned_dst) % sizeof(*dst), 0);
 
   // Write all but the last char
-  nchars = str->Write(aligned_dst, 0, max_chars - 1, flags);
+  nchars = str->Write(isolate, aligned_dst, 0, max_chars - 1, flags);
 
   // Shift everything to unaligned-left
   memmove(dst, aligned_dst, nchars * sizeof(*dst));
 
   // One more char to be written
   uint16_t last;
-  if (nchars == max_chars - 1 && str->Write(&last, nchars, 1, flags) != 0) {
+  if (nchars == max_chars - 1 &&
+      str->Write(isolate, &last, nchars, 1, flags) != 0) {
     memcpy(buf + nchars * sizeof(*dst), &last, sizeof(last));
     nchars++;
   }
@@ -294,7 +295,6 @@ size_t StringBytes::WriteUCS2(char* buf,
   *chars_written = nchars;
   return nchars * sizeof(*dst);
 }
-
 
 size_t StringBytes::Write(Isolate* isolate,
                           char* buf,
@@ -325,20 +325,20 @@ size_t StringBytes::Write(Isolate* isolate,
         memcpy(buf, ext->data(), nbytes);
       } else {
         uint8_t* const dst = reinterpret_cast<uint8_t*>(buf);
-        nbytes = str->WriteOneByte(dst, 0, buflen, flags);
+        nbytes = str->WriteOneByte(isolate, dst, 0, buflen, flags);
       }
       *chars_written = nbytes;
       break;
 
     case BUFFER:
     case UTF8:
-      nbytes = str->WriteUtf8(buf, buflen, chars_written, flags);
+      nbytes = str->WriteUtf8(isolate, buf, buflen, chars_written, flags);
       break;
 
     case UCS2: {
       size_t nchars;
 
-      nbytes = WriteUCS2(buf, buflen, str, flags, &nchars);
+      nbytes = WriteUCS2(isolate, buf, buflen, str, flags, &nchars);
       *chars_written = static_cast<int>(nchars);
 
       // Node's "ucs2" encoding wants LE character data stored in
@@ -460,7 +460,7 @@ size_t StringBytes::Size(Isolate* isolate,
 
     case BUFFER:
     case UTF8:
-      return str->Utf8Length();
+      return str->Utf8Length(isolate);
 
     case UCS2:
       return str->Length() * sizeof(uint16_t);

--- a/src/string_bytes.h
+++ b/src/string_bytes.h
@@ -112,7 +112,8 @@ class StringBytes {
                                           v8::Local<v8::Value>* error);
 
  private:
-  static size_t WriteUCS2(char* buf,
+  static size_t WriteUCS2(v8::Isolate* isolate,
+                          char* buf,
                           size_t buflen,
                           v8::Local<v8::String> str,
                           int flags,

--- a/src/string_decoder.cc
+++ b/src/string_decoder.cc
@@ -226,7 +226,7 @@ MaybeLocal<String> StringDecoder::DecodeData(Isolate* isolate,
     if (prepend.IsEmpty()) {
       return body;
     } else {
-      return String::Concat(prepend, body);
+      return String::Concat(isolate, prepend, body);
     }
   } else {
     CHECK(Encoding() == ASCII || Encoding() == HEX || Encoding() == LATIN1);

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -174,7 +174,8 @@ void TCPWrap::SetNoDelay(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
-  int enable = static_cast<int>(args[0]->BooleanValue());
+  int enable = static_cast<int>(
+      args[0]->BooleanValue(wrap->env()->context()).FromMaybe(false));
   int err = uv_tcp_nodelay(&wrap->handle_, enable);
   args.GetReturnValue().Set(err);
 }
@@ -185,8 +186,9 @@ void TCPWrap::SetKeepAlive(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
-  int enable = args[0]->Int32Value();
-  unsigned int delay = args[1]->Uint32Value();
+  int enable = args[0]->Int32Value(wrap->env()->context()).FromMaybe(0);
+  unsigned int delay =
+      args[1]->Uint32Value(wrap->env()->context()).FromMaybe(0);
   int err = uv_tcp_keepalive(&wrap->handle_, enable, delay);
   args.GetReturnValue().Set(err);
 }
@@ -198,7 +200,7 @@ void TCPWrap::SetSimultaneousAccepts(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
-  bool enable = args[0]->BooleanValue();
+  bool enable = args[0]->BooleanValue(env->context()).FromMaybe(false);
   int err = uv_tcp_simultaneous_accepts(&wrap->handle_, enable);
   args.GetReturnValue().Set(err);
 }
@@ -210,7 +212,8 @@ void TCPWrap::Open(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
-  int fd = static_cast<int>(args[0]->IntegerValue());
+  int fd = static_cast<int>(
+      args[0]->IntegerValue(wrap->env()->context()).FromMaybe(0));
   int err = uv_tcp_open(&wrap->handle_, fd);
 
   if (err == 0)
@@ -226,7 +229,7 @@ void TCPWrap::Bind(const FunctionCallbackInfo<Value>& args) {
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
   node::Utf8Value ip_address(args.GetIsolate(), args[0]);
-  int port = args[1]->Int32Value();
+  int port = args[1]->Int32Value(wrap->env()->context()).FromMaybe(0);
   sockaddr_in addr;
   int err = uv_ip4_addr(*ip_address, port, &addr);
   if (err == 0) {
@@ -244,7 +247,7 @@ void TCPWrap::Bind6(const FunctionCallbackInfo<Value>& args) {
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
   node::Utf8Value ip6_address(args.GetIsolate(), args[0]);
-  int port = args[1]->Int32Value();
+  int port = args[1]->Int32Value(wrap->env()->context()).FromMaybe(0);
   sockaddr_in6 addr;
   int err = uv_ip6_addr(*ip6_address, port, &addr);
   if (err == 0) {
@@ -261,7 +264,7 @@ void TCPWrap::Listen(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
-  int backlog = args[0]->Int32Value();
+  int backlog = args[0]->Int32Value(wrap->env()->context()).FromMaybe(0);
   int err = uv_listen(reinterpret_cast<uv_stream_t*>(&wrap->handle_),
                       backlog,
                       OnConnection);
@@ -283,7 +286,7 @@ void TCPWrap::Connect(const FunctionCallbackInfo<Value>& args) {
 
   Local<Object> req_wrap_obj = args[0].As<Object>();
   node::Utf8Value ip_address(env->isolate(), args[1]);
-  int port = args[2]->Uint32Value();
+  int port = args[2]->Uint32Value(wrap->env()->context()).FromMaybe(0);
 
   sockaddr_in addr;
   int err = uv_ip4_addr(*ip_address, port, &addr);
@@ -318,7 +321,7 @@ void TCPWrap::Connect6(const FunctionCallbackInfo<Value>& args) {
 
   Local<Object> req_wrap_obj = args[0].As<Object>();
   node::Utf8Value ip_address(env->isolate(), args[1]);
-  int port = args[2]->Int32Value();
+  int port = args[2]->Int32Value(wrap->env()->context()).FromMaybe(0);
 
   sockaddr_in6 addr;
   int err = uv_ip6_addr(*ip_address, port, &addr);

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -80,7 +80,7 @@ uv_tty_t* TTYWrap::UVHandle() {
 
 void TTYWrap::GuessHandleType(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-  int fd = args[0]->Int32Value();
+  int fd = args[0]->Int32Value(env->context()).FromMaybe(0);
   CHECK_GE(fd, 0);
 
   uv_handle_type t = uv_guess_handle(fd);
@@ -102,7 +102,7 @@ void TTYWrap::GuessHandleType(const FunctionCallbackInfo<Value>& args) {
 
 
 void TTYWrap::IsTTY(const FunctionCallbackInfo<Value>& args) {
-  int fd = args[0]->Int32Value();
+  int fd = args[0]->Int32Value(args.Holder()->CreationContext()).FromMaybe(0);
   CHECK_GE(fd, 0);
   bool rc = uv_guess_handle(fd) == UV_TTY;
   args.GetReturnValue().Set(rc);
@@ -149,7 +149,7 @@ void TTYWrap::New(const FunctionCallbackInfo<Value>& args) {
   // normal function.
   CHECK(args.IsConstructCall());
 
-  int fd = args[0]->Int32Value();
+  int fd = args[0]->Int32Value(env->context()).FromMaybe(0);
   CHECK_GE(fd, 0);
 
   int err = 0;

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -177,8 +177,8 @@ void UDPWrap::DoBind(const FunctionCallbackInfo<Value>& args, int family) {
   CHECK_EQ(args.Length(), 3);
 
   node::Utf8Value address(args.GetIsolate(), args[0]);
-  const int port = args[1]->Uint32Value();
-  const int flags = args[2]->Uint32Value();
+  const int port = args[1]->Uint32Value(wrap->env()->context()).FromMaybe(0);
+  const int flags = args[2]->Uint32Value(wrap->env()->context()).FromMaybe(0);
   char addr[sizeof(sockaddr_in6)];
   int err;
 
@@ -249,14 +249,13 @@ void UDPWrap::BufferSize(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(size);
 }
 
-
-#define X(name, fn)                                                           \
-  void UDPWrap::name(const FunctionCallbackInfo<Value>& args) {               \
-    UDPWrap* wrap = Unwrap<UDPWrap>(args.Holder());                           \
-    CHECK_EQ(args.Length(), 1);                                               \
-    int flag = args[0]->Int32Value();                                         \
-    int err = wrap == nullptr ? UV_EBADF : fn(&wrap->handle_, flag);          \
-    args.GetReturnValue().Set(err);                                           \
+#define X(name, fn)                                                      \
+  void UDPWrap::name(const FunctionCallbackInfo<Value>& args) {          \
+    UDPWrap* wrap = Unwrap<UDPWrap>(args.Holder());                      \
+    CHECK_EQ(args.Length(), 1);                                          \
+    int flag = args[0]->Int32Value(wrap->env()->context()).FromMaybe(0); \
+    int err = wrap == nullptr ? UV_EBADF : fn(&wrap->handle_, flag);     \
+    args.GetReturnValue().Set(err);                                      \
   }
 
 X(SetTTL, uv_udp_set_ttl)
@@ -338,8 +337,8 @@ void UDPWrap::DoSend(const FunctionCallbackInfo<Value>& args, int family) {
   Local<Array> chunks = args[1].As<Array>();
   // it is faster to fetch the length of the
   // array in js-land
-  size_t count = args[2]->Uint32Value();
-  const unsigned short port = args[3]->Uint32Value();
+  size_t count = args[2]->Uint32Value(env->context()).FromMaybe(0);
+  const unsigned short port = args[3]->Uint32Value(env->context()).FromMaybe(0);
   node::Utf8Value address(env->isolate(), args[4]);
   const bool have_callback = args[5]->IsTrue();
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -44,7 +44,8 @@ static void MakeUtf8String(Isolate* isolate,
   target->AllocateSufficientStorage(storage);
   const int flags =
       String::NO_NULL_TERMINATION | String::REPLACE_INVALID_UTF8;
-  const int length = string->WriteUtf8(target->out(), storage, 0, flags);
+  const int length =
+      string->WriteUtf8(isolate, target->out(), storage, 0, flags);
   target->SetLengthAndZeroTerminate(length);
 }
 
@@ -70,7 +71,7 @@ TwoByteValue::TwoByteValue(Isolate* isolate, Local<Value> value) {
   AllocateSufficientStorage(storage);
 
   const int flags = String::NO_NULL_TERMINATION;
-  const int length = string->Write(out(), 0, storage, flags);
+  const int length = string->Write(isolate, out(), 0, storage, flags);
   SetLengthAndZeroTerminate(length);
 }
 

--- a/src/uv.cc
+++ b/src/uv.cc
@@ -43,7 +43,7 @@ using v8::Value;
 // lib/util.getSystemErrorName()
 void ErrName(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-  int err = args[0]->Int32Value();
+  int err = args[0]->Int32Value(env->context()).FromMaybe(0);
   CHECK_LT(err, 0);
   const char* name = uv_err_name(err);
   args.GetReturnValue().Set(OneByteString(env->isolate(), name));


### PR DESCRIPTION
API calls that implicitly get an Isolate or Context are deprecated
in V8 6.9, and will go away soon. This is because V8 will soon
start sharing read-only objects between Isolates, thus making it
impossible to infer the Isolate from some objects (such as strings).

This commit replaces the deprecated calls with the non-deprecated
equivalents.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
    - Some tests are failing for me locally both before and after the patch, looks like unrelated permissions issues though.
- [x] tests and/or benchmarks are included
    - N/A
- [x] documentation is changed or added
    - N/A
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
