### PR TITLE
v8: clean up ToNumberValue for known Numbers

### DIFF
--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -482,18 +482,15 @@ void AsyncWrap::AsyncReset(const FunctionCallbackInfo<Value>& args) {
   AsyncWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
   double execution_async_id =
-      args[0]->IsNumber()
-          ? args[0]->NumberValue(wrap->env()->context()).ToChecked()
-          : -1;
+      args[0]->IsNumber() ? args[0].As<Number>()->Value() : -1;
   wrap->AsyncReset(execution_async_id);
 }
 
 
 void AsyncWrap::QueueDestroyAsyncId(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsNumber());
-  Environment* env = Environment::GetCurrent(args);
-  AsyncWrap::EmitDestroy(env,
-                         args[0]->NumberValue(env->context()).FromMaybe(0));
+  AsyncWrap::EmitDestroy(Environment::GetCurrent(args),
+                         args[0].As<Number>()->Value());
 }
 
 void AsyncWrap::AddWrapMethods(Environment* env,

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -234,9 +234,9 @@ void Open(const FunctionCallbackInfo<Value>& args) {
   Agent* agent = env->inspector_agent();
   bool wait_for_connect = false;
 
-  uint32_t port;
-  if (args.Length() > 0 && args[0]->Uint32Value(env->context()).To(&port)) {
-    agent->options().set_port(static_cast<int>(port));
+  if (args.Length() > 0 && args[0]->IsUint32()) {
+    agent->options().set_port(
+        static_cast<int>(args[0].As<v8::Uint32>()->Value()));
   }
 
   if (args.Length() > 1 && args[1]->IsString()) {

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -81,6 +81,7 @@ using v8::Isolate;
 using v8::Local;
 using v8::Maybe;
 using v8::MaybeLocal;
+using v8::Number;
 using v8::Object;
 using v8::String;
 using v8::Uint32Array;
@@ -824,7 +825,7 @@ void IndexOfString(const FunctionCallbackInfo<Value>& args) {
   SPREAD_BUFFER_ARG(args[0], ts_obj);
 
   Local<String> needle = args[1].As<String>();
-  int64_t offset_i64 = args[2]->IntegerValue(env->context()).FromMaybe(0);
+  int64_t offset_i64 = args[2].As<Integer>()->Value();
   bool is_forward = args[4]->IsTrue();
 
   const char* haystack = ts_obj_data;
@@ -941,7 +942,7 @@ void IndexOfBuffer(const FunctionCallbackInfo<Value>& args) {
   THROW_AND_RETURN_UNLESS_BUFFER(env, args[1]);
   SPREAD_BUFFER_ARG(args[0], ts_obj);
   SPREAD_BUFFER_ARG(args[1], buf);
-  int64_t offset_i64 = args[2]->IntegerValue(env->context()).FromMaybe(0);
+  int64_t offset_i64 = args[2].As<Integer>()->Value();
   bool is_forward = args[4]->IsTrue();
 
   const char* haystack = ts_obj_data;
@@ -1011,8 +1012,8 @@ void IndexOfNumber(const FunctionCallbackInfo<Value>& args) {
   THROW_AND_RETURN_UNLESS_BUFFER(env, args[0]);
   SPREAD_BUFFER_ARG(args[0], ts_obj);
 
-  uint32_t needle = args[1]->Uint32Value(env->context()).FromMaybe(0);
-  int64_t offset_i64 = args[2]->IntegerValue(env->context()).FromMaybe(0);
+  uint32_t needle = static_cast<uint32_t>(args[1].As<Number>()->Value());
+  int64_t offset_i64 = args[2].As<Integer>()->Value();
   bool is_forward = args[3]->IsTrue();
 
   int64_t opt_offset = IndexOfOffset(ts_obj_length, offset_i64, 1, is_forward);

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1041,8 +1041,7 @@ void SecureContext::SetSessionTimeout(const FunctionCallbackInfo<Value>& args) {
         sc->env(), "Session timeout must be a 32-bit integer");
   }
 
-  int32_t sessionTimeout =
-      args[0]->Int32Value(sc->env()->context()).FromMaybe(0);
+  int32_t sessionTimeout = args[0].As<Int32>()->Value();
   SSL_CTX_set_timeout(sc->ctx_.get(), sessionTimeout);
 }
 
@@ -4054,15 +4053,14 @@ void DiffieHellman::New(const FunctionCallbackInfo<Value>& args) {
   if (args.Length() == 2) {
     if (args[0]->IsInt32()) {
       if (args[1]->IsInt32()) {
-        initialized = diffieHellman->Init(
-            args[0]->Int32Value(env->context()).FromMaybe(0),
-            args[1]->Int32Value(env->context()).FromMaybe(0));
+        initialized = diffieHellman->Init(args[0].As<Int32>()->Value(),
+                                          args[1].As<Int32>()->Value());
       }
     } else {
       if (args[1]->IsInt32()) {
-        initialized = diffieHellman->Init(
-            Buffer::Data(args[0]), Buffer::Length(args[0]),
-            args[1]->Int32Value(env->context()).FromMaybe(0));
+        initialized =
+            diffieHellman->Init(Buffer::Data(args[0]), Buffer::Length(args[0]),
+                                args[1].As<Int32>()->Value());
       } else {
         initialized = diffieHellman->Init(Buffer::Data(args[0]),
                                           Buffer::Length(args[0]),

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -93,6 +93,7 @@ using v8::MaybeLocal;
 using v8::Object;
 using v8::ObjectTemplate;
 using v8::String;
+using v8::Uint32;
 using v8::Value;
 
 namespace i18n {
@@ -817,7 +818,7 @@ static void GetStringWidth(const FunctionCallbackInfo<Value>& args) {
 
   if (args[0]->IsNumber()) {
     args.GetReturnValue().Set(
-        GetColumnWidth(args[0]->Uint32Value(env->context()).FromMaybe(0),
+        GetColumnWidth(static_cast<uint32_t>(args[0].As<Uint32>()->Value()),
                        ambiguous_as_full_width));
     return;
   }

--- a/src/node_process.cc
+++ b/src/node_process.cc
@@ -310,20 +310,20 @@ static const char* name_by_gid(gid_t gid) {
 }
 #endif
 
-static uid_t uid_by_name(Environment* env, Local<Value> value) {
+static uid_t uid_by_name(Isolate* isolate, Local<Value> value) {
   if (value->IsUint32()) {
-    return static_cast<uid_t>(value->Uint32Value(env->context()).ToChecked());
+    return static_cast<uid_t>(value.As<v8::Uint32>()->Value());
   } else {
-    Utf8Value name(env->isolate(), value);
+    Utf8Value name(isolate, value);
     return uid_by_name(*name);
   }
 }
 
-static gid_t gid_by_name(Environment* env, Local<Value> value) {
+static gid_t gid_by_name(Isolate* isolate, Local<Value> value) {
   if (value->IsUint32()) {
-    return static_cast<uid_t>(value->Uint32Value(env->context()).ToChecked());
+    return static_cast<uid_t>(value.As<v8::Uint32>()->Value());
   } else {
-    Utf8Value name(env->isolate(), value);
+    Utf8Value name(isolate, value);
     return gid_by_name(*name);
   }
 }
@@ -359,7 +359,7 @@ void SetGid(const FunctionCallbackInfo<Value>& args) {
   CHECK_EQ(args.Length(), 1);
   CHECK(args[0]->IsUint32() || args[0]->IsString());
 
-  gid_t gid = gid_by_name(env, args[0]);
+  gid_t gid = gid_by_name(env->isolate(), args[0]);
 
   if (gid == gid_not_found) {
     // Tells JS to throw ERR_INVALID_CREDENTIAL
@@ -379,7 +379,7 @@ void SetEGid(const FunctionCallbackInfo<Value>& args) {
   CHECK_EQ(args.Length(), 1);
   CHECK(args[0]->IsUint32() || args[0]->IsString());
 
-  gid_t gid = gid_by_name(env, args[0]);
+  gid_t gid = gid_by_name(env->isolate(), args[0]);
 
   if (gid == gid_not_found) {
     // Tells JS to throw ERR_INVALID_CREDENTIAL
@@ -399,7 +399,7 @@ void SetUid(const FunctionCallbackInfo<Value>& args) {
   CHECK_EQ(args.Length(), 1);
   CHECK(args[0]->IsUint32() || args[0]->IsString());
 
-  uid_t uid = uid_by_name(env, args[0]);
+  uid_t uid = uid_by_name(env->isolate(), args[0]);
 
   if (uid == uid_not_found) {
     // Tells JS to throw ERR_INVALID_CREDENTIAL
@@ -419,7 +419,7 @@ void SetEUid(const FunctionCallbackInfo<Value>& args) {
   CHECK_EQ(args.Length(), 1);
   CHECK(args[0]->IsUint32() || args[0]->IsString());
 
-  uid_t uid = uid_by_name(env, args[0]);
+  uid_t uid = uid_by_name(env->isolate(), args[0]);
 
   if (uid == uid_not_found) {
     // Tells JS to throw ERR_INVALID_CREDENTIAL
@@ -479,7 +479,7 @@ void SetGroups(const FunctionCallbackInfo<Value>& args) {
   gid_t* groups = new gid_t[size];
 
   for (size_t i = 0; i < size; i++) {
-    gid_t gid = gid_by_name(env, groups_list->Get(i));
+    gid_t gid = gid_by_name(env->isolate(), groups_list->Get(i));
 
     if (gid == gid_not_found) {
       delete[] groups;
@@ -514,7 +514,7 @@ void InitGroups(const FunctionCallbackInfo<Value>& args) {
   char* user;
 
   if (args[0]->IsUint32()) {
-    user = name_by_uid(args[0]->Uint32Value(env->context()).ToChecked());
+    user = name_by_uid(args[0].As<Uint32>()->Value());
     must_free = true;
   } else {
     user = *arg0;
@@ -526,7 +526,7 @@ void InitGroups(const FunctionCallbackInfo<Value>& args) {
     return args.GetReturnValue().Set(1);
   }
 
-  extra_group = gid_by_name(env, args[1]);
+  extra_group = gid_by_name(env->isolate(), args[1]);
 
   if (extra_group == gid_not_found) {
     if (must_free)

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -45,6 +45,7 @@ using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::HandleScope;
+using v8::Int32;
 using v8::Local;
 using v8::Number;
 using v8::Object;
@@ -416,8 +417,8 @@ class ZCtx : public AsyncWrap, public ThreadPoolWork {
   static void New(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args);
     CHECK(args[0]->IsInt32());
-    node_zlib_mode mode = static_cast<node_zlib_mode>(
-        args[0]->Int32Value(env->context()).FromMaybe(0));
+    node_zlib_mode mode =
+        static_cast<node_zlib_mode>(args[0].As<Int32>()->Value());
     new ZCtx(env, args.This(), mode);
   }
 


### PR DESCRIPTION
Clean up some ToNumberValue (and ToInt32Value, etc.) conversions
where the input is already known to be a Number, and in these cases
use value.As<Number>->Value() instead.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
    - N/A
- [x] documentation is changed or added
    - N/A
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
