### PR TITLE
v8: remove remaining deprecated V8 API calls

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -487,7 +487,8 @@ void Add(const FunctionCallbackInfo<Value>& args) {
   }
 
   // Perform the operation
-  double value = args[0]->NumberValue() + args[1]->NumberValue();
+  double value = args[0].As<v8::Number>()->Value() +
+                 args[1].As<v8::Number>()->Value();
   Local<Number> num = Number::New(isolate, value);
 
   // Set the return value (using the passed in
@@ -593,7 +594,8 @@ void CreateObject(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
 
   Local<Object> obj = Object::New(isolate);
-  obj->Set(String::NewFromUtf8(isolate, "msg"), args[0]->ToString());
+  obj->Set(String::NewFromUtf8(isolate, "msg"),
+           args[0]->ToString(isolate));
 
   args.GetReturnValue().Set(obj);
 }
@@ -779,10 +781,11 @@ void MyObject::Init(Local<Object> exports) {
 
 void MyObject::New(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
+  Local<Context> context = isolate->GetCurrentContext();
 
   if (args.IsConstructCall()) {
     // Invoked as constructor: `new MyObject(...)`
-    double value = args[0]->IsUndefined() ? 0 : args[0]->NumberValue();
+    double value = args[0]->NumberValue(context).FromMaybe(0);
     MyObject* obj = new MyObject(value);
     obj->Wrap(args.This());
     args.GetReturnValue().Set(args.This());
@@ -790,7 +793,6 @@ void MyObject::New(const FunctionCallbackInfo<Value>& args) {
     // Invoked as plain function `MyObject(...)`, turn into construct call.
     const int argc = 1;
     Local<Value> argv[argc] = { args[0] };
-    Local<Context> context = isolate->GetCurrentContext();
     Local<Function> cons = Local<Function>::New(isolate, constructor);
     Local<Object> result =
         cons->NewInstance(context, argc, argv).ToLocalChecked();
@@ -961,10 +963,11 @@ void MyObject::Init(Isolate* isolate) {
 
 void MyObject::New(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
+  Local<Context> context = isolate->GetCurrentContext();
 
   if (args.IsConstructCall()) {
     // Invoked as constructor: `new MyObject(...)`
-    double value = args[0]->IsUndefined() ? 0 : args[0]->NumberValue();
+    double value = args[0]->NumberValue(context).FromMaybe(0);
     MyObject* obj = new MyObject(value);
     obj->Wrap(args.This());
     args.GetReturnValue().Set(args.This());
@@ -973,7 +976,6 @@ void MyObject::New(const FunctionCallbackInfo<Value>& args) {
     const int argc = 1;
     Local<Value> argv[argc] = { args[0] };
     Local<Function> cons = Local<Function>::New(isolate, constructor);
-    Local<Context> context = isolate->GetCurrentContext();
     Local<Object> instance =
         cons->NewInstance(context, argc, argv).ToLocalChecked();
     args.GetReturnValue().Set(instance);
@@ -1076,9 +1078,9 @@ void Add(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
 
   MyObject* obj1 = node::ObjectWrap::Unwrap<MyObject>(
-      args[0]->ToObject());
+      args[0]->ToObject(isolate));
   MyObject* obj2 = node::ObjectWrap::Unwrap<MyObject>(
-      args[1]->ToObject());
+      args[1]->ToObject(isolate));
 
   double sum = obj1->value() + obj2->value();
   args.GetReturnValue().Set(Number::New(isolate, sum));
@@ -1168,10 +1170,11 @@ void MyObject::Init(Isolate* isolate) {
 
 void MyObject::New(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
+  Local<Context> context = isolate->GetCurrentContext();
 
   if (args.IsConstructCall()) {
     // Invoked as constructor: `new MyObject(...)`
-    double value = args[0]->IsUndefined() ? 0 : args[0]->NumberValue();
+    double value = args[0]->NumberValue(context).FromMaybe(0);
     MyObject* obj = new MyObject(value);
     obj->Wrap(args.This());
     args.GetReturnValue().Set(args.This());
@@ -1179,7 +1182,6 @@ void MyObject::New(const FunctionCallbackInfo<Value>& args) {
     // Invoked as plain function `MyObject(...)`, turn into construct call.
     const int argc = 1;
     Local<Value> argv[argc] = { args[0] };
-    Local<Context> context = isolate->GetCurrentContext();
     Local<Function> cons = Local<Function>::New(isolate, constructor);
     Local<Object> instance =
         cons->NewInstance(context, argc, argv).ToLocalChecked();

--- a/src/node.cc
+++ b/src/node.cc
@@ -3034,7 +3034,7 @@ static void DebugProcess(const FunctionCallbackInfo<Value>& args) {
     goto out;
   }
 
-  pid = (DWORD) args[0]->IntegerValue();
+  pid = (DWORD)args[0]->IntegerValue(env->context()).FromMaybe(0);
 
   process = OpenProcess(PROCESS_CREATE_THREAD | PROCESS_QUERY_INFORMATION |
                             PROCESS_VM_OPERATION | PROCESS_VM_WRITE |

--- a/src/node.h
+++ b/src/node.h
@@ -297,7 +297,8 @@ NODE_EXTERN struct uv_loop_s* GetCurrentEventLoop(v8::Isolate* isolate);
 /* Converts a unixtime to V8 Date */
 #define NODE_UNIXTIME_V8(t) v8::Date::New(v8::Isolate::GetCurrent(),          \
     1000 * static_cast<double>(t))
-#define NODE_V8_UNIXTIME(v) (static_cast<double>((v)->NumberValue())/1000.0);
+#define NODE_V8_UNIXTIME(v) \
+  ((v)->IsNumber() ? (v).As<Number>()->Value() / 1000.0 : 0);
 
 #define NODE_DEFINE_CONSTANT(target, constant)                                \
   do {                                                                        \

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1263,9 +1263,9 @@ int SecureContext::TicketKeyCallback(SSL* ssl,
                                         {0, 0}).ToLocalChecked();
   Local<Array> arr = ret.As<Array>();
 
-  int r;
-  if (!arr->Get(kTicketKeyReturnIndex)->Int32Value(env->context()).To(&r) ||
-      r < 0)
+  int r =
+      arr->Get(kTicketKeyReturnIndex)->Int32Value(env->context()).FromMaybe(0);
+  if (r < 0)
     return r;
 
   Local<Value> hmac = arr->Get(kTicketKeyHMACIndex);

--- a/src/node_dtrace.cc
+++ b/src/node_dtrace.cc
@@ -69,13 +69,15 @@ using v8::Value;
   if ((*(const char **)valp = *_##member) == nullptr)                      \
     *(const char **)valp = "<unknown>";
 
-#define SLURP_INT(obj, member, valp)                                       \
-  if (!(obj)->IsObject()) {                                                \
-    return node::THROW_ERR_INVALID_ARG_TYPE(env,                           \
-        "expected object for " #obj " to contain integer member " #member);\
-  }                                                                        \
-  *valp = obj->Get(OneByteString(env->isolate(), #member))                 \
-      ->Int32Value();
+#define SLURP_INT(obj, member, valp)                                        \
+  if (!(obj)->IsObject()) {                                                 \
+    return node::THROW_ERR_INVALID_ARG_TYPE(                                \
+        env,                                                                \
+        "expected object for " #obj " to contain integer member " #member); \
+  }                                                                         \
+  *valp = obj->Get(OneByteString(env->isolate(), #member))                  \
+              ->Int32Value(env->context())                                  \
+              .FromMaybe(0);
 
 #define SLURP_OBJECT(obj, member, valp)                                    \
   if (!(obj)->IsObject()) {                                                \

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -119,7 +119,8 @@ class TimerWrap : public HandleWrap {
 
     CHECK(HandleWrap::IsAlive(wrap));
 
-    int64_t timeout = args[0]->IntegerValue();
+    int64_t timeout =
+        args[0]->IntegerValue(wrap->env()->context()).FromMaybe(0);
     int err = uv_timer_start(&wrap->handle_, OnTimeout, timeout, 0);
     args.GetReturnValue().Set(err);
   }

--- a/test/addons/async-hello-world/binding.cc
+++ b/test/addons/async-hello-world/binding.cc
@@ -73,7 +73,7 @@ void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
   async_req* req = new async_req;
   req->req.data = req;
 
-  req->input = args[0]->IntegerValue();
+  req->input = args[0]->IntegerValue(isolate->GetCurrentContext()).FromMaybe(0);
   req->output = 0;
   req->isolate = isolate;
   req->context = node::EmitAsyncInit(isolate, v8::Object::New(isolate), "test");

--- a/test/addons/buffer-free-callback/binding.cc
+++ b/test/addons/buffer-free-callback/binding.cc
@@ -13,20 +13,19 @@ static void FreeCallback(char* data, void* hint) {
 
 void Alloc(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
   alive++;
 
-  uintptr_t alignment = args[1]->IntegerValue();
-  uintptr_t offset = args[2]->IntegerValue();
+  uintptr_t alignment = args[1]->IntegerValue(context).FromMaybe(0);
+  uintptr_t offset = args[2]->IntegerValue(context).FromMaybe(0);
 
   uintptr_t static_offset = reinterpret_cast<uintptr_t>(buf) % alignment;
   char* aligned = buf + (alignment - static_offset) + offset;
 
-  args.GetReturnValue().Set(node::Buffer::New(
-        isolate,
-        aligned,
-        args[0]->IntegerValue(),
-        FreeCallback,
-        nullptr).ToLocalChecked());
+  args.GetReturnValue().Set(
+      node::Buffer::New(isolate, aligned, args[0].As<v8::Integer>()->Value(),
+                        FreeCallback, nullptr)
+          .ToLocalChecked());
 }
 
 void Check(const v8::FunctionCallbackInfo<v8::Value>& args) {

--- a/test/addons/stringbytes-external-exceed-max/binding.cc
+++ b/test/addons/stringbytes-external-exceed-max/binding.cc
@@ -4,7 +4,8 @@
 
 void EnsureAllocation(const v8::FunctionCallbackInfo<v8::Value> &args) {
   v8::Isolate* isolate = args.GetIsolate();
-  uintptr_t size = args[0]->IntegerValue();
+  uintptr_t size =
+      args[0]->IntegerValue(isolate->GetCurrentContext()).FromMaybe(0);
   v8::Local<v8::Boolean> success;
 
   void* buffer = malloc(size);


### PR DESCRIPTION
Remove a couple more deprecated V8 API calls that were missed in
the previous patches.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
