### PR TITLE
test: fix percentage of stale memory

### DIFF
--- a/test/parallel/test-zlib-unused-weak.js
+++ b/test/parallel/test-zlib-unused-weak.js
@@ -13,6 +13,6 @@ const afterCreation = process.memoryUsage().external;
 global.gc();
 const afterGC = process.memoryUsage().external;
 
-assert((afterGC - before) / (afterCreation - before) <= 0.05,
-       `Expected after-GC delta ${afterGC - before} to be less than 5 %` +
+assert((afterGC - before) / (afterCreation - before) <= 0.1,
+       `Expected after-GC delta ${afterGC - before} to be less than 10 %` +
        ` of before-GC delta ${afterCreation - before}`);


### PR DESCRIPTION
The test ensure that after garbage collection the memory delta is within 5%.
The limit is relatively close though as it depends on how much external memory
is reported initially. A change in reporting lets it rise to slightly over 5%
making the test fail.

Push delta limit to 10% to check against leaks but be robust against smaller
reporting changes.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
