### PR TITLE
test: remove --harmony-bigint flag

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1016,10 +1016,7 @@ added: v10.0.0
 
 * Returns: {boolean}
 
-Returns `true` if the value is a `BigInt64Array` instance. The
-`--harmony-bigint` command line flag is required in order to use the
-`BigInt64Array` type, but it is not required in order to use
-`isBigInt64Array()`.
+Returns `true` if the value is a `BigInt64Array` instance.
 
 For example:
 

--- a/test/parallel/test-util-inspect-bigint.js
+++ b/test/parallel/test-util-inspect-bigint.js
@@ -1,7 +1,5 @@
 'use strict';
 
-// Flags: --harmony-bigint
-
 require('../common');
 const assert = require('assert');
 

--- a/test/parallel/test-util-types.js
+++ b/test/parallel/test-util-types.js
@@ -1,4 +1,4 @@
-// Flags: --harmony-bigint --experimental-vm-modules
+// Flags: --experimental-vm-modules
 'use strict';
 const common = require('../common');
 const fixtures = require('../common/fixtures');


### PR DESCRIPTION
The flag will be removed in in V8: https://chromium-review.googlesource.com/c/v8/v8/+/1253604

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
