### PR TITLE
Fix build bot link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ cd v8-node
 make -j4 node
 ```
 
-Or download the latest build for Ubuntu from this [build bot](https://build.chromium.org/p/client.v8.fyi/builders/V8%20-%20node.js%20integration). Select a build, then use *Archive link download*.
+Or download the latest build for Ubuntu from this [build bot](https://ci.chromium.org/p/v8/builders/luci.v8.ci/V8%20Linux64%20-%20node.js%20integration/). Select a build, then use the *download* link.
 
 To check the V8 version in Node, have a look at [`v8-version.h`](https://github.com/v8/node/blob/vee-eight-lkgr/deps/v8/include/v8-version.h) or run
 ```console


### PR DESCRIPTION
The build bot link was pointing to an old  "V8 - node.js integration" bot, which is supposedly renamed to "V8 Linux64 - node.js integration". Updated that link and the text for the "download" link.

##### Checklist

- [x] documentation is changed or added

