### PR TITLE
platform: Ensure no more foreground tasks after Deinit

### DIFF
--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -265,7 +265,8 @@ void PerIsolatePlatformData::Shutdown() {
   if (flush_tasks_ == nullptr)
     return;
 
-  while (FlushForegroundTasksInternal()) {}
+  CHECK_NULL(foreground_delayed_tasks_.Pop());
+  CHECK_NULL(foreground_tasks_.Pop());
   CancelPendingDelayedTasks();
 
   uv_close(reinterpret_cast<uv_handle_t*>(flush_tasks_),


### PR DESCRIPTION
Node first calls Isolate::Dispose, then NodePlatform::UnregisterIsolate.
This again calls PerIsolatePlatformData::Shutdown, which (before this
patch) called FlushForegroundTasksInternal, which might call
RunForegroundTask if it finds foreground tasks to be executed. This
will fail however, since Isolate::GetCurrent was already reset during
Isolate::Dispose.
Hence remove the check to FlushForegroundTasksInternal and add checks
instead that no more foreground tasks are scheduled.