### PR TITLE
lib: stringify should cache only the first line of the error message

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -53,15 +53,18 @@ function tryStringify(arg) {
   try {
     return JSON.stringify(arg);
   } catch (err) {
+    function firstErrorLine(error) { return error.message.split('\n')[0]; }
+
     // Populate the circular error message lazily
     if (!CIRCULAR_ERROR_MESSAGE) {
       try {
         const a = {}; a.a = a; JSON.stringify(a);
       } catch (err) {
-        CIRCULAR_ERROR_MESSAGE = err.message;
+        CIRCULAR_ERROR_MESSAGE = firstErrorLine(err);
       }
     }
-    if (err.name === 'TypeError' && err.message === CIRCULAR_ERROR_MESSAGE)
+    if (err.name === 'TypeError' &&
+        firstErrorLine(err) === CIRCULAR_ERROR_MESSAGE)
       return '[Circular]';
     throw err;
   }


### PR DESCRIPTION
V8 extends the error message for JSON#stringify when encountering
circular structures. The first line of the new error message
is equivalent to the old error message and stays the same across
all circular structure errors.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
