### PR TITLE
Keep 31bit Smi and pointer compression options in sync

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -330,6 +330,16 @@ parser.add_option('--enable-d8',
     dest='enable_d8',
     help=optparse.SUPPRESS_HELP)  # Unsupported, undocumented.
 
+parser.add_option('--enable-pointer-compression',
+    action='store_true',
+    dest='enable_pointer_compression',
+    help=optparse.SUPPRESS_HELP)  # Unsupported, undocumented.
+
+parser.add_option('--enable-31bit-smis',
+    action='store_true',
+    dest='enable_31bit_smis',
+    help=optparse.SUPPRESS_HELP)  # Unsupported, undocumented.
+
 parser.add_option('--enable-trace-maps',
     action='store_true',
     dest='trace_maps',
@@ -1181,8 +1191,9 @@ def configure_v8(o):
   o['variables']['node_use_bundled_v8'] = b(not options.without_bundled_v8)
   o['variables']['force_dynamic_crt'] = 1 if options.shared else 0
   o['variables']['node_enable_d8'] = b(options.enable_d8)
-  o['variables']['v8_enable_pointer_compression'] = 0
-  o['variables']['v8_enable_31bit_smis_on_64bit_arch'] = 0
+  o['variables']['v8_enable_pointer_compression'] = b(options.enable_pointer_compression)
+  o['variables']['v8_enable_31bit_smis_on_64bit_arch'] = \
+    b(options.enable_pointer_compression or options.enable_31bit_smis)
   # Unconditionally force typed arrays to allocate outside the v8 heap. This
   # is to prevent memory pointers from being moved around that are returned by
   # Buffer::Data().
@@ -1214,6 +1225,10 @@ def configure_v8(o):
         os.environ.get('DEPOT_TOOLS_WIN_TOOLCHAIN_ROOT', ''))
     o['variables']['build_v8_with_gn_depot_tools'] = b(depot_tools)
   o['variables']['build_v8_with_gn'] = b(options.build_v8_with_gn)
+  if o['variables']['v8_enable_31bit_smis_on_64bit_arch'] == 'true':
+    o['defines'] += ['V8_31BIT_SMIS_ON_64BIT_ARCH']
+  if o['variables']['v8_enable_pointer_compression'] == 'true':
+    o['defines'] += ['V8_COMPRESS_POINTERS']
 
 
 def configure_openssl(o):

--- a/deps/v8/gypfiles/v8-monolithic.gyp
+++ b/deps/v8/gypfiles/v8-monolithic.gyp
@@ -63,6 +63,8 @@
             '--flag', 'v8_enable_disassembler=<(v8_enable_disassembler)',
             '--flag', 'v8_postmortem_support=<(v8_postmortem_support)',
             '--flag', 'v8_untrusted_code_mitigations=<(v8_untrusted_code_mitigations)',
+            '--flag', 'v8_enable_31bit_smis_on_64bit_arch=<(v8_enable_31bit_smis_on_64bit_arch)',
+            '--flag', 'v8_enable_pointer_compression=<(v8_enable_pointer_compression)',
             '--bundled-win-toolchain', '<(build_v8_with_gn_bundled_win_toolchain)',
             '--depot-tools', '<(build_v8_with_gn_depot_tools)',
           ],


### PR DESCRIPTION
This change ensures that node is in control of defining options
for pointer compression and 31bit Smis, overriding the defaults
of V8 if necessary (change to v8-monolithic.gyp).

The change also ensures that if one of the features is enabled,
node #defines the preprocessor symbols
  V8_31BIT_SMIS_ON_64BIT_ARCH
  V8_COMPRESS_POINTERS
if necessary. This ensures that a V8 header (which may contain
an #if conditions depending on one of those symbols) gets the
same defines independent of whether they are included from a
.cc file that is part of V8 or part of node.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
