### PR TITLE
[v8] Replace WasmCompiledModule by WasmModuleObject

### DIFF
--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -31,7 +31,7 @@ using v8::String;
 using v8::Value;
 using v8::ValueDeserializer;
 using v8::ValueSerializer;
-using v8::WasmCompiledModule;
+using v8::WasmModuleObject;
 
 namespace node {
 namespace worker {
@@ -50,7 +50,7 @@ class DeserializerDelegate : public ValueDeserializer::Delegate {
       Environment* env,
       const std::vector<MessagePort*>& message_ports,
       const std::vector<Local<SharedArrayBuffer>>& shared_array_buffers,
-      const std::vector<WasmCompiledModule::TransferrableModule>& wasm_modules)
+      const std::vector<WasmModuleObject::TransferrableModule>& wasm_modules)
       : message_ports_(message_ports),
         shared_array_buffers_(shared_array_buffers),
         wasm_modules_(wasm_modules) {}
@@ -71,10 +71,10 @@ class DeserializerDelegate : public ValueDeserializer::Delegate {
     return shared_array_buffers_[clone_id];
   }
 
-  MaybeLocal<WasmCompiledModule> GetWasmModuleFromId(
+  MaybeLocal<WasmModuleObject> GetWasmModuleFromId(
       Isolate* isolate, uint32_t transfer_id) override {
     CHECK_LE(transfer_id, wasm_modules_.size());
-    return WasmCompiledModule::FromTransferrableModule(
+    return WasmModuleObject::FromTransferrableModule(
         isolate, wasm_modules_[transfer_id]);
   }
 
@@ -83,7 +83,7 @@ class DeserializerDelegate : public ValueDeserializer::Delegate {
  private:
   const std::vector<MessagePort*>& message_ports_;
   const std::vector<Local<SharedArrayBuffer>>& shared_array_buffers_;
-  const std::vector<WasmCompiledModule::TransferrableModule>& wasm_modules_;
+  const std::vector<WasmModuleObject::TransferrableModule>& wasm_modules_;
 };
 
 }  // anonymous namespace
@@ -171,7 +171,7 @@ void Message::AddMessagePort(std::unique_ptr<MessagePortData>&& data) {
   message_ports_.emplace_back(std::move(data));
 }
 
-uint32_t Message::AddWASMModule(WasmCompiledModule::TransferrableModule&& mod) {
+uint32_t Message::AddWASMModule(WasmModuleObject::TransferrableModule&& mod) {
   wasm_modules_.emplace_back(std::move(mod));
   return wasm_modules_.size() - 1;
 }
@@ -236,7 +236,7 @@ class SerializerDelegate : public ValueSerializer::Delegate {
   }
 
   Maybe<uint32_t> GetWasmModuleTransferId(
-      Isolate* isolate, Local<WasmCompiledModule> module) override {
+      Isolate* isolate, Local<WasmModuleObject> module) override {
     return Just(msg_->AddWASMModule(module->GetTransferrableModule()));
   }
 

--- a/src/node_messaging.h
+++ b/src/node_messaging.h
@@ -49,7 +49,7 @@ class Message : public MemoryRetainer {
   void AddMessagePort(std::unique_ptr<MessagePortData>&& data);
   // Internal method of Message that is called when a new WebAssembly.Module
   // object is encountered in the incoming value's structure.
-  uint32_t AddWASMModule(v8::WasmCompiledModule::TransferrableModule&& mod);
+  uint32_t AddWASMModule(v8::WasmModuleObject::TransferrableModule&& mod);
 
   // The MessagePorts that will be transferred, as recorded by Serialize().
   // Used for warning user about posting the target MessagePort to itself,
@@ -68,7 +68,7 @@ class Message : public MemoryRetainer {
   std::vector<MallocedBuffer<char>> array_buffer_contents_;
   std::vector<SharedArrayBufferMetadataReference> shared_array_buffers_;
   std::vector<std::unique_ptr<MessagePortData>> message_ports_;
-  std::vector<v8::WasmCompiledModule::TransferrableModule> wasm_modules_;
+  std::vector<v8::WasmModuleObject::TransferrableModule> wasm_modules_;
 
   friend class MessagePort;
 };


### PR DESCRIPTION
WasmCompiledModule is a typedef to WasmModuleObject which is deprecated
since last December (https://crrev.com/c/1370035).

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
