### PR TITLE
src: remove deprecated api in ObjectWrap assert

### DIFF
--- a/src/node_object_wrap.h
+++ b/src/node_object_wrap.h
@@ -38,7 +38,6 @@ class ObjectWrap {
   virtual ~ObjectWrap() {
     if (persistent().IsEmpty())
       return;
-    assert(persistent().IsNearDeath());
     persistent().ClearWeak();
     persistent().Reset();
   }


### PR DESCRIPTION
IsNearDeath is deprecated and should not be queried anymore.


##### Checklist
- [x ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
