### PR TITLE
util: Fix wrong usage of Error.prepareStackTrace

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -351,7 +351,7 @@ function isInsideNodeModules() {
     // the perf implications should be okay.
     getStructuredStack = runInNewContext(`(function() {
       Error.prepareStackTrace = function(err, trace) {
-        err.stack = trace;
+        return trace;
       };
       Error.stackTraceLimit = Infinity;
 


### PR DESCRIPTION
The return value of Error.prepareStackTrace will become the result
of Error.stack accesses. Setting Error.stack inside this callback
relies on the fact that the magic get accessor detects the change in
the middle of formatting, and is unnecessary in this instance.

Note: This PR was already [approved](https://github.com/v8/node/pull/96), just sent to the wrong branch.