### PR TITLE
Disable SyntaxError tests in preparation for CL

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -9,6 +9,9 @@ prefix parallel
 test-net-connect-options-port: PASS,FLAKY
 # https://github.com/nodejs/node/issues/26401
 test-worker-prof: PASS,FLAKY
+# https://chromium-review.googlesource.com/c/v8/v8/+/1593307
+test-v8-flags: SKIP
+test-vm-basic: SKIP
 
 [$system==win32]
 test-http2-pipe: PASS,FLAKY


### PR DESCRIPTION
Temporarily disabled tests affected by [this CL](https://chromium-review.googlesource.com/c/v8/v8/+/1593307).

I'm not sure I selected the right destination branch here. I'm hoping to make the change such that I can immediately have the trybot succeed after updating `node-ci`.