### PR TITLE
Stop overriding deprecated V8 methods

### DIFF
--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -149,14 +149,6 @@ class NodePlatform : public MultiIsolatePlatform {
   void CallOnWorkerThread(std::unique_ptr<v8::Task> task) override;
   void CallDelayedOnWorkerThread(std::unique_ptr<v8::Task> task,
                                  double delay_in_seconds) override;
-  void CallOnForegroundThread(v8::Isolate* isolate, v8::Task* task) override {
-    UNREACHABLE();
-  }
-  void CallDelayedOnForegroundThread(v8::Isolate* isolate,
-                                     v8::Task* task,
-                                     double delay_in_seconds) override {
-    UNREACHABLE();
-  }
   bool IdleTasksEnabled(v8::Isolate* isolate) override;
   double MonotonicallyIncreasingTime() override;
   double CurrentClockTimeMillis() override;


### PR DESCRIPTION
These methods will be removed in V8 8.1, hence we need to stop
overriding them.

##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
