### PR TITLE
Update tests for larger Buffers

### DIFF
--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -8,8 +8,8 @@ const SlowBuffer = require('buffer').SlowBuffer;
 // Verify the maximum Uint8Array size. There is no concrete limit by spec. The
 // internal limits should be updated if this fails.
 assert.throws(
-  () => new Uint8Array(2 ** 31),
-  { message: 'Invalid typed array length: 2147483648' }
+  () => new Uint8Array(2 ** 32),
+  { message: 'Invalid typed array length: 4294967296' }
 );
 
 const b = Buffer.allocUnsafe(1024);

--- a/test/parallel/test-buffer-over-max-length.js
+++ b/test/parallel/test-buffer-over-max-length.js
@@ -25,5 +25,5 @@ assert.throws(() => Buffer.allocUnsafe(kMaxLength + 1), bufferMaxSizeMsg);
 assert.throws(() => Buffer.allocUnsafeSlow(kMaxLength + 1), bufferMaxSizeMsg);
 
 // issue GH-4331
-assert.throws(() => Buffer.allocUnsafe(0xFFFFFFFF), bufferMaxSizeMsg);
+assert.throws(() => Buffer.allocUnsafe(0x100000000), bufferMaxSizeMsg);
 assert.throws(() => Buffer.allocUnsafe(0xFFFFFFFFF), bufferMaxSizeMsg);


### PR DESCRIPTION
V8 is about to increase the max TypedArray length to 2**32-1, which
Node inherits as Buffer.kMaxLength. Some tests relied on values greater
than the previous max length (2**31-1) to throw errors; this updates
those tests for the new max length.
