### PR TITLE
Remove checks for deserializing wasm

### DIFF
--- a/test/parallel/test-v8-serdes.js
+++ b/test/parallel/test-v8-serdes.js
@@ -23,8 +23,7 @@ const objects = [
   undefined,
   null,
   42,
-  circular,
-  wasmModule
+  circular
 ];
 
 const hostObject = new (internalBinding('js_stream').JSStream)();
@@ -238,7 +237,12 @@ const deserializerTypeError =
 }
 
 {
-  const deserializedWasmModule = v8.deserialize(v8.serialize(wasmModule));
-  const instance = new WebAssembly.Instance(deserializedWasmModule);
-  assert.strictEqual(instance.exports.add(10, 20), 30);
+  // V8 is removing support for serializing wasm modules via the value
+  // serializer. Once this is complete (https://crrev.com/c/2013110), we can
+  // re-add this test:
+  //assert.throws(
+  //  () => v8.serialize(wasmModule), {
+  //    constructor: Error,
+  //    message: '#<Module> could not be cloned.'
+  //  });
 }


### PR DESCRIPTION
Serialization support of WasmModuleObjects will be removed in
https://crrev.com/c/2013110, thus we need to stop testing for that.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
