### PR TITLE
Rename NodeArrayBufferAllocator::Reallocate

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -117,11 +117,11 @@ void DebuggingArrayBufferAllocator::Free(void* data, size_t size) {
   NodeArrayBufferAllocator::Free(data, size);
 }
 
-void* DebuggingArrayBufferAllocator::Reallocate(void* data,
+void* DebuggingArrayBufferAllocator::ReallocateBuffer(void* data,
                                                 size_t old_size,
                                                 size_t size) {
   Mutex::ScopedLock lock(mutex_);
-  void* ret = NodeArrayBufferAllocator::Reallocate(data, old_size, size);
+  void* ret = NodeArrayBufferAllocator::ReallocateBuffer(data, old_size, size);
   if (ret == nullptr) {
     if (size == 0)  // i.e. equivalent to free().
       UnregisterPointerInternal(data, old_size);

--- a/src/env.cc
+++ b/src/env.cc
@@ -1027,7 +1027,8 @@ char* Environment::Reallocate(char* data, size_t old_size, size_t size) {
   // if reallocate directly.
   if (isolate_data()->uses_node_allocator()) {
     return static_cast<char*>(
-        isolate_data()->node_allocator()->Reallocate(data, old_size, size));
+        isolate_data()->node_allocator()->ReallocateBuffer(
+            data, old_size, size));
   }
   // Generic allocators do not provide a reallocation method; we need to
   // allocate a new chunk of memory and copy the data over.

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -112,7 +112,11 @@ class NodeArrayBufferAllocator : public ArrayBufferAllocator {
   void* AllocateUninitialized(size_t size) override
     { return node::UncheckedMalloc(size); }
   void Free(void* data, size_t) override { free(data); }
-  virtual void* Reallocate(void* data, size_t old_size, size_t size) {
+  // This function is temporarily renamed to ReallocateBuffer to avoid
+  // conflict with the new V8 API function called Reallocate.
+  // Once the V8 with the new API is rolled in Node, this should be renamed
+  // back to Reallocate with the override attribute.
+  virtual void* ReallocateBuffer(void* data, size_t old_size, size_t size) {
     return static_cast<void*>(
         UncheckedRealloc<char>(static_cast<char*>(data), size));
   }
@@ -131,7 +135,7 @@ class DebuggingArrayBufferAllocator final : public NodeArrayBufferAllocator {
   void* Allocate(size_t size) override;
   void* AllocateUninitialized(size_t size) override;
   void Free(void* data, size_t size) override;
-  void* Reallocate(void* data, size_t old_size, size_t size) override;
+  void* ReallocateBuffer(void* data, size_t old_size, size_t size) override;
   void RegisterPointer(void* data, size_t size) override;
   void UnregisterPointer(void* data, size_t size) override;
 


### PR DESCRIPTION
This temporarily renames Reallocate to ReallocateBuffer in order
to unblock V8 roll that introduces a new Reallocate function:
https://chromium-review.googlesource.com/c/v8/v8/+/2007274

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
