### PR TITLE
Avoid calling deprecated method

### DIFF
--- a/src/node_serdes.cc
+++ b/src/node_serdes.cc
@@ -286,7 +286,6 @@ DeserializerContext::DeserializerContext(Environment* env,
     length_(Buffer::Length(buffer)),
     deserializer_(env->isolate(), data_, length_, this) {
   object()->Set(env->context(), env->buffer_string(), buffer).Check();
-  deserializer_.SetExpectInlineWasm(true);
 
   MakeWeak();
 }


### PR DESCRIPTION
The {SetExpectInlineWasm} method is deprecated and non-functional since
V8 v8.1. Calling this method has no effect.
Thus node should stop calling it, so that it can be fully removed in a
future v8 version.