### PR TITLE
Remove deprecated wasm type check

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1867,21 +1867,6 @@ Returns `true` if the value is a built-in [`WeakSet`][] instance.
 util.types.isWeakSet(new WeakSet());  // Returns true
 ```
 
-### `util.types.isWebAssemblyCompiledModule(value)`
-<!-- YAML
-added: v10.0.0
--->
-
-* `value` {any}
-* Returns: {boolean}
-
-Returns `true` if the value is a built-in [`WebAssembly.Module`][] instance.
-
-```js
-const module = new WebAssembly.Module(wasmBuffer);
-util.types.isWebAssemblyCompiledModule(module);  // Returns true
-```
-
 ## Deprecated APIs
 
 The following APIs are deprecated and should no longer be used. Existing
@@ -2331,6 +2316,24 @@ timestamp.
 const util = require('util');
 
 util.log('Timestamped message.');
+```
+
+### `util.types.isWebAssemblyCompiledModule(value)`
+<!-- YAML
+added: v10.0.0
+deprecated: v14.0.0
+-->
+
+> Stability: 0 - Deprecated: Use `value instanceof WebAssembly.Module` instead.
+
+* `value` {any}
+* Returns: {boolean}
+
+Returns `true` if the value is a built-in [`WebAssembly.Module`][] instance.
+
+```js
+const module = new WebAssembly.Module(wasmBuffer);
+util.types.isWebAssemblyCompiledModule(module);  // Returns true
 ```
 
 [`'uncaughtException'`]: process.html#process_event_uncaughtexception

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1867,6 +1867,24 @@ Returns `true` if the value is a built-in [`WeakSet`][] instance.
 util.types.isWeakSet(new WeakSet());  // Returns true
 ```
 
+### `util.types.isWebAssemblyCompiledModule(value)`
+<!-- YAML
+added: v10.0.0
+deprecated: REPLACEME
+-->
+
+> Stability: 0 - Deprecated: Use `value instanceof WebAssembly.Module` instead.
+
+* `value` {any}
+* Returns: {boolean}
+
+Returns `true` if the value is a built-in [`WebAssembly.Module`][] instance.
+
+```js
+const module = new WebAssembly.Module(wasmBuffer);
+util.types.isWebAssemblyCompiledModule(module);  // Returns true
+```
+
 ## Deprecated APIs
 
 The following APIs are deprecated and should no longer be used. Existing
@@ -2316,24 +2334,6 @@ timestamp.
 const util = require('util');
 
 util.log('Timestamped message.');
-```
-
-### `util.types.isWebAssemblyCompiledModule(value)`
-<!-- YAML
-added: v10.0.0
-deprecated: v14.0.0
--->
-
-> Stability: 0 - Deprecated: Use `value instanceof WebAssembly.Module` instead.
-
-* `value` {any}
-* Returns: {boolean}
-
-Returns `true` if the value is a built-in [`WebAssembly.Module`][] instance.
-
-```js
-const module = new WebAssembly.Module(wasmBuffer);
-util.types.isWebAssemblyCompiledModule(module);  // Returns true
 ```
 
 [`'uncaughtException'`]: process.html#process_event_uncaughtexception

--- a/src/node_types.cc
+++ b/src/node_types.cc
@@ -35,7 +35,6 @@ namespace {
   V(DataView)                                                                 \
   V(SharedArrayBuffer)                                                        \
   V(Proxy)                                                                    \
-  V(WebAssemblyCompiledModule)                                                \
   V(ModuleNamespaceObject)                                                    \
 
 

--- a/test/parallel/test-util-types.js
+++ b/test/parallel/test-util-types.js
@@ -1,7 +1,6 @@
 // Flags: --experimental-vm-modules --expose-internals
 'use strict';
 require('../common');
-const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const { types, inspect } = require('util');
 const vm = require('vm');
@@ -9,7 +8,6 @@ const { internalBinding } = require('internal/test/binding');
 const { JSStream } = internalBinding('js_stream');
 
 const external = (new JSStream())._externalStream;
-const wasmBuffer = fixtures.readSync('simple.wasm');
 
 for (const [ value, _method ] of [
   [ external, 'isExternal' ],
@@ -50,7 +48,6 @@ for (const [ value, _method ] of [
   [ new DataView(new ArrayBuffer()) ],
   [ new SharedArrayBuffer() ],
   [ new Proxy({}, {}), 'isProxy' ],
-  [ new WebAssembly.Module(wasmBuffer), 'isWebAssemblyCompiledModule' ],
 ]) {
   const method = _method || `is${value.constructor.name}`;
   assert(method in types, `Missing ${method} for ${inspect(value)}`);


### PR DESCRIPTION
This removes uses of the "IsWebAssemblyCompiledModule" method, which is
deprecated in V8 v8.1 and will be removed in v8.2.
We could replace it by "IsWasmModuleObject", but since it's unused in
node (C++) anyway, and there are better ways to check for wasm modules in js,
I just remove the definition.