### PR TITLE
No concurrent array buffer sweeping for some tests

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -17,6 +17,10 @@ test-domain-error-types: SKIP
 test-v8-flags: SKIP
 test-vm-basic: SKIP
 test-http-pipeline-requests-connection-leak: SKIP
+# Skip tests until --no-concurrent-array-buffer-sweeping is supported
+# by the V8 version used in Node.
+test-memory-usage: SKIP
+test-zlib-unused-weak: SKIP
 
 [$system==win32]
 # https://github.com/nodejs/node/issues/20750

--- a/test/parallel/test-memory-usage.js
+++ b/test/parallel/test-memory-usage.js
@@ -18,7 +18,7 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
-
+// Flags: --no-concurrent-array-buffer-sweeping
 'use strict';
 const common = require('../common');
 const assert = require('assert');

--- a/test/parallel/test-zlib-unused-weak.js
+++ b/test/parallel/test-zlib-unused-weak.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose-gc
+// Flags: --expose-gc --no-concurrent-array-buffer-sweeping
 require('../common');
 const assert = require('assert');
 const zlib = require('zlib');


### PR DESCRIPTION
Add --no-concurrent-array-buffer-sweeping to two tests that would fail otherwise with concurrent array buffer sweeping enabled.
