### PR TITLE
Revert FinalizationRegistry test skipping commit

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -21,10 +21,6 @@ test-http-pipeline-requests-connection-leak: SKIP
 # by the V8 version used in Node.
 test-memory-usage: SKIP
 test-zlib-unused-weak: SKIP
-# Skip temporarily to land FinalizationGroup to FinalizationRegistry rename
-test-finalization-group-error: SKIP
-test-finalization-group-regular-gc: SKIP
-test-finalization-group: SKIP
 
 [$system==win32]
 # https://github.com/nodejs/node/issues/20750


### PR DESCRIPTION
V8 landed the [rename CL](https://chromium.googlesource.com/v8/v8/+/ff89c6bc6fc3204bf9bb921e4d511d81feb76551) so we can un-skip the tests now.