### PR TITLE
Remove use of the deprecated FinalizationGroup hooks

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -16,7 +16,6 @@ using errors::TryCatchScope;
 using v8::Array;
 using v8::Context;
 using v8::EscapableHandleScope;
-using v8::FinalizationGroup;
 using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::HandleScope;
@@ -81,15 +80,6 @@ static MaybeLocal<Value> PrepareStackTraceCallback(Local<Context> context,
     try_catch.ReThrow();
   }
   return result;
-}
-
-static void HostCleanupFinalizationGroupCallback(
-    Local<Context> context, Local<FinalizationGroup> group) {
-  Environment* env = Environment::GetCurrent(context);
-  if (env == nullptr) {
-    return;
-  }
-  env->RegisterFinalizationGroupForCleanup(group);
 }
 
 void* NodeArrayBufferAllocator::Allocate(size_t size) {
@@ -259,11 +249,6 @@ void SetIsolateMiscHandlers(v8::Isolate* isolate, const IsolateSettings& s) {
   auto* promise_reject_cb = s.promise_reject_callback ?
     s.promise_reject_callback : task_queue::PromiseRejectCallback;
   isolate->SetPromiseRejectCallback(promise_reject_cb);
-
-  auto* host_cleanup_cb = s.host_cleanup_finalization_group_callback ?
-    s.host_cleanup_finalization_group_callback :
-    HostCleanupFinalizationGroupCallback;
-  isolate->SetHostCleanupFinalizationGroupCallback(host_cleanup_cb);
 
   if (s.flags & DETAILED_SOURCE_POSITIONS_FOR_PROFILING)
     v8::CpuProfiler::UseDetailedSourcePositionsForProfiling(isolate);

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -1225,13 +1225,6 @@ void Environment::RemoveCleanupHook(void (*fn)(void*), void* arg) {
   cleanup_hooks_.erase(search);
 }
 
-inline void Environment::RegisterFinalizationGroupForCleanup(
-    v8::Local<v8::FinalizationGroup> group) {
-  cleanup_finalization_groups_.emplace_back(isolate(), group);
-  DCHECK(task_queues_async_initialized_);
-  uv_async_send(&task_queues_async_);
-}
-
 size_t CleanupHookCallback::Hash::operator()(
     const CleanupHookCallback& cb) const {
   return std::hash<void*>()(cb.arg_);

--- a/src/env.cc
+++ b/src/env.cc
@@ -30,7 +30,6 @@ using v8::ArrayBuffer;
 using v8::Boolean;
 using v8::Context;
 using v8::EmbedderGraph;
-using v8::FinalizationGroup;
 using v8::Function;
 using v8::FunctionTemplate;
 using v8::HandleScope;
@@ -475,7 +474,6 @@ void Environment::InitializeLibuv(bool start_profiler_idle_notifier) {
       [](uv_async_t* async) {
         Environment* env = ContainerOf(
             &Environment::task_queues_async_, async);
-        env->CleanupFinalizationGroups();
         env->RunAndClearNativeImmediates();
       });
   uv_unref(reinterpret_cast<uv_handle_t*>(&idle_prepare_handle_));
@@ -1107,26 +1105,6 @@ char* Environment::Reallocate(char* data, size_t old_size, size_t size) {
 
 void Environment::RunWeakRefCleanup() {
   isolate()->ClearKeptObjects();
-}
-
-void Environment::CleanupFinalizationGroups() {
-  HandleScope handle_scope(isolate());
-  Context::Scope context_scope(context());
-  TryCatchScope try_catch(this);
-
-  while (!cleanup_finalization_groups_.empty() && can_call_into_js()) {
-    Local<FinalizationGroup> fg =
-        cleanup_finalization_groups_.front().Get(isolate());
-    cleanup_finalization_groups_.pop_front();
-    if (!FinalizationGroup::Cleanup(fg).FromMaybe(false)) {
-      if (try_catch.HasCaught() && !try_catch.HasTerminated())
-        errors::TriggerUncaughtException(isolate(), try_catch);
-      // Re-schedule the execution of the remainder of the queue.
-      CHECK(task_queues_async_initialized_);
-      uv_async_send(&task_queues_async_);
-      return;
-    }
-  }
 }
 
 // Not really any better place than env.cc at this moment.

--- a/src/env.h
+++ b/src/env.h
@@ -1115,9 +1115,7 @@ class Environment : public MemoryRetainer {
   void AtExit(void (*cb)(void* arg), void* arg);
   void RunAtExitCallbacks();
 
-  void RegisterFinalizationGroupForCleanup(v8::Local<v8::FinalizationGroup> fg);
   void RunWeakRefCleanup();
-  void CleanupFinalizationGroups();
 
   // Strings and private symbols are shared across shared contexts
   // The getters simply proxy to the per-isolate primitive.
@@ -1335,8 +1333,6 @@ class Environment : public MemoryRetainer {
   uint64_t flags_;
   uint64_t thread_id_;
   std::unordered_set<worker::Worker*> sub_worker_contexts_;
-
-  std::deque<v8::Global<v8::FinalizationGroup>> cleanup_finalization_groups_;
 
   static void* const kNodeContextTagPtr;
   static int const kNodeContextTag;

--- a/src/node.h
+++ b/src/node.h
@@ -352,8 +352,6 @@ struct IsolateSettings {
   v8::PromiseRejectCallback promise_reject_callback = nullptr;
   v8::AllowWasmCodeGenerationCallback
       allow_wasm_code_generation_callback = nullptr;
-  v8::HostCleanupFinalizationGroupCallback
-      host_cleanup_finalization_group_callback = nullptr;
 };
 
 // Overriding IsolateSettings may produce unexpected behavior


### PR DESCRIPTION
Now that WeakRefs has shipped, I'd like to remove the deprecated V8 APIs around FinalizationGroup integration.

The V8 CL is [here](https://chromium-review.googlesource.com/c/v8/v8/+/2171696)
Node upstream is in the process of upgrading to 8.3, so it'll probably be a ~month until the uses can actually be removed from upstream.

I would prefer to not wait for a month to land the V8 CL, but then this patch would be something we'd have to maintain. What do you think, @victorgomes?