### PR TITLE
Disable tests to update TypedArray size

### DIFF
--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -1,5 +1,9 @@
 'use strict';
 const common = require('../common');
+
+// crbug.com/1095721
+common.skip('Temporarily disabling to update TypedArray size.');
+
 const assert = require('assert');
 const vm = require('vm');
 

--- a/test/parallel/test-buffer-over-max-length.js
+++ b/test/parallel/test-buffer-over-max-length.js
@@ -1,5 +1,9 @@
 'use strict';
-require('../common');
+const common = require('../common');
+
+// crbug.com/1095721
+common.skip('Temporarily disabling to update TypedArray size.');
+
 const assert = require('assert');
 
 const buffer = require('buffer');


### PR DESCRIPTION
This temporarily disables two tests that check the allowed buffer size, which is inherited from v8 via Buffer.kMaxLength. V8 is going to increase the size to 2 ** 32.