### PR TITLE
Update tests after increasing typed array size

### DIFF
--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -1,9 +1,6 @@
 'use strict';
 const common = require('../common');
 
-// crbug.com/1095721
-common.skip('Temporarily disabling to update TypedArray size.');
-
 const assert = require('assert');
 const vm = require('vm');
 
@@ -12,8 +9,8 @@ const SlowBuffer = require('buffer').SlowBuffer;
 // Verify the maximum Uint8Array size. There is no concrete limit by spec. The
 // internal limits should be updated if this fails.
 assert.throws(
-  () => new Uint8Array(2 ** 32),
-  { message: 'Invalid typed array length: 4294967296' }
+  () => new Uint8Array(2 ** 32 + 1),
+  { message: 'Invalid typed array length: 4294967297' }
 );
 
 const b = Buffer.allocUnsafe(1024);

--- a/test/parallel/test-buffer-over-max-length.js
+++ b/test/parallel/test-buffer-over-max-length.js
@@ -1,8 +1,5 @@
 'use strict';
-const common = require('../common');
-
-// crbug.com/1095721
-common.skip('Temporarily disabling to update TypedArray size.');
+require('../common');
 
 const assert = require('assert');
 
@@ -16,11 +13,11 @@ const bufferMaxSizeMsg = {
   message: /^The value "[^"]*" is invalid for option "size"$/
 };
 
-assert.throws(() => Buffer((-1 >>> 0) + 1), bufferMaxSizeMsg);
-assert.throws(() => SlowBuffer((-1 >>> 0) + 1), bufferMaxSizeMsg);
-assert.throws(() => Buffer.alloc((-1 >>> 0) + 1), bufferMaxSizeMsg);
-assert.throws(() => Buffer.allocUnsafe((-1 >>> 0) + 1), bufferMaxSizeMsg);
-assert.throws(() => Buffer.allocUnsafeSlow((-1 >>> 0) + 1), bufferMaxSizeMsg);
+assert.throws(() => Buffer((-1 >>> 0) + 2), bufferMaxSizeMsg);
+assert.throws(() => SlowBuffer((-1 >>> 0) + 2), bufferMaxSizeMsg);
+assert.throws(() => Buffer.alloc((-1 >>> 0) + 2), bufferMaxSizeMsg);
+assert.throws(() => Buffer.allocUnsafe((-1 >>> 0) + 2), bufferMaxSizeMsg);
+assert.throws(() => Buffer.allocUnsafeSlow((-1 >>> 0) + 2), bufferMaxSizeMsg);
 
 assert.throws(() => Buffer(kMaxLength + 1), bufferMaxSizeMsg);
 assert.throws(() => SlowBuffer(kMaxLength + 1), bufferMaxSizeMsg);
@@ -29,5 +26,5 @@ assert.throws(() => Buffer.allocUnsafe(kMaxLength + 1), bufferMaxSizeMsg);
 assert.throws(() => Buffer.allocUnsafeSlow(kMaxLength + 1), bufferMaxSizeMsg);
 
 // issue GH-4331
-assert.throws(() => Buffer.allocUnsafe(0x100000000), bufferMaxSizeMsg);
+assert.throws(() => Buffer.allocUnsafe(0x100000001), bufferMaxSizeMsg);
 assert.throws(() => Buffer.allocUnsafe(0xFFFFFFFFF), bufferMaxSizeMsg);


### PR DESCRIPTION
This adapts the tests after having changed the maximum size in v8 for a typed array to 4GB.