### PR TITLE
Fast api unwrap

### DIFF
--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -469,7 +469,6 @@ class FastHrtime : public BaseObject {
   SET_MEMORY_INFO_NAME(FastHrtime)
   SET_SELF_SIZE(FastHrtime)
 
-  template <typename T>
   static FastHrtime* FromV8ApiObject(v8::ApiObject api_object) {
     v8::Object* v8_object = reinterpret_cast<v8::Object*>(&api_object);
     return static_cast<FastHrtime*>(

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -478,7 +478,10 @@ class FastHrtime : public BaseObject {
   // broken into the upper/lower 32 bits to be converted back in JS,
   // because there is no Uint64Array in JS.
   // The third entry contains the remaining nanosecond part of the value.
-  static void FastNumber(FastHrtime* receiver) {
+  static void FastNumber(v8::ApiObject receiver_value) {
+    v8::Object* receiver_obj = reinterpret_cast<v8::Object*>(&receiver_value);
+    FastHrtime* receiver = static_cast<FastHrtime*>(
+        receiver_obj->GetAlignedPointerFromInternalField(BaseObject::kSlot));
     uint64_t t = uv_hrtime();
     uint32_t* fields = static_cast<uint32_t*>(receiver->backing_store_->Data());
     fields[0] = (t / NANOS_PER_SEC) >> 32;
@@ -490,7 +493,10 @@ class FastHrtime : public BaseObject {
     FastNumber(FromJSObject<FastHrtime>(args.Holder()));
   }
 
-  static void FastBigInt(FastHrtime* receiver) {
+  static void FastBigInt(v8::ApiObject receiver_value) {
+    v8::Object* receiver_obj = reinterpret_cast<v8::Object*>(&receiver_value);
+    FastHrtime* receiver = static_cast<FastHrtime*>(
+        receiver_obj->GetAlignedPointerFromInternalField(BaseObject::kSlot));
     uint64_t t = uv_hrtime();
     uint64_t* fields = static_cast<uint64_t*>(receiver->backing_store_->Data());
     fields[0] = t;
@@ -543,17 +549,6 @@ static void InitializeProcessMethods(Local<Object> target,
 }
 
 }  // namespace node
-
-namespace v8 {
-template <>
-class WrapperTraits<node::FastHrtime> {
- public:
-  static const void* GetTypeInfo() {
-    static const int tag = 0;
-    return reinterpret_cast<const void*>(&tag);
-  }
-};
-}  // namespace v8
 
 NODE_MODULE_CONTEXT_AWARE_INTERNAL(process_methods,
                                    node::InitializeProcessMethods)

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -493,11 +493,11 @@ class FastHrtime : public BaseObject {
   }
 
   static void FastNumber(v8::ApiObject receiver) {
-    NumperImpl(FromV8ApiObject(receiver));
+    NumberImpl(FromV8ApiObject(receiver));
   }
 
   static void SlowNumber(const FunctionCallbackInfo<Value>& args) {
-    NumperImpl(FromJSObject<FastHrtime>(args.Holder()));
+    NumberImpl(FromJSObject<FastHrtime>(args.Holder()));
   }
 
   static void BigIntImpl(FastHrtime* receiver) {


### PR DESCRIPTION
[upstream:v8.6.218] process: update v8 fast api calls usage
    
This commit removes the WrapperTraits specialization for FastHrtime
according to recent changes in the V8 API.
    
Refs: https://github.com/nodejs/node/issues/33374

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
