### PR TITLE
[upstream:v8.7] Import mjs files in js2c

### DIFF
--- a/tools/js2c.py
+++ b/tools/js2c.py
@@ -141,6 +141,9 @@ def JS2C(source_files, target):
   for filename in source_files['.js']:
     AddModule(filename, definitions, initializers)
 
+  for filename in source_files['.mjs']:
+    AddModule(filename, definitions, initializers)
+
   config_def, config_size = handle_config_gypi(source_files['config.gypi'])
   definitions.append(config_def)
 
@@ -206,8 +209,8 @@ def main():
   global is_verbose
   is_verbose = options.verbose
   source_files = functools.reduce(SourceFileByExt, options.sources, {})
-  # Should have exactly 2 types: `.js`, and `.gypi`
-  assert len(source_files) == 2
+  # Should have exactly 3 types: `.js`, `.mjs`,  and `.gypi`
+  assert sorted(source_files.keys()) == ['.gypi', '.js', '.mjs']
   # Currently config.gypi is the only `.gypi` file allowed
   assert source_files['.gypi'] == ['config.gypi']
   source_files['config.gypi'] = source_files.pop('.gypi')[0]


### PR DESCRIPTION
JS files in tools/* are being converted to ES6 modules that need to be supported in js2c.py.
This CL imports the files but js2c.py doesn't handle them properly yet.

