### PR TITLE
inspector: do not hardcode Debugger.CallFrameId in tests

### DIFF
--- a/test/common/inspector-helper.js
+++ b/test/common/inspector-helper.js
@@ -130,6 +130,7 @@ class InspectorSession {
     this._unprocessedNotifications = [];
     this._notificationCallback = null;
     this._scriptsIdsByUrl = new Map();
+    this._pausedDetails = null;
 
     let buffer = Buffer.alloc(0);
     socket.on('data', (data) => {
@@ -179,6 +180,10 @@ class InspectorSession {
           this.mainScriptId = scriptId;
         }
       }
+      if (message.method === 'Debugger.paused')
+        this._pausedDetails = message.params;
+      if (message.method === 'Debugger.resumed')
+        this._pausedDetails = null;
 
       if (this._notificationCallback) {
         // In case callback needs to install another
@@ -265,6 +270,10 @@ class InspectorSession {
         (notification) =>
           this._isBreakOnLineNotification(notification, line, url),
         `break on ${url}:${line}`);
+  }
+
+  pausedDetails() {
+    return this._pausedDetails;
   }
 
   _matchesConsoleOutputNotification(notification, type, values) {

--- a/test/parallel/test-inspector-esm.js
+++ b/test/parallel/test-inspector-esm.js
@@ -78,7 +78,7 @@ async function testBreakpoint(session) {
 
   let { result } = await session.send({
     'method': 'Debugger.evaluateOnCallFrame', 'params': {
-      'callFrameId': '{"ordinal":0,"injectedScriptId":1}',
+      'callFrameId': session.pausedDetails().callFrames[0].callFrameId,
       'expression': 'k + t',
       'objectGroup': 'console',
       'includeCommandLineAPI': true,

--- a/test/sequential/test-inspector.js
+++ b/test/sequential/test-inspector.js
@@ -116,7 +116,7 @@ async function testBreakpoint(session) {
 
   let { result } = await session.send({
     'method': 'Debugger.evaluateOnCallFrame', 'params': {
-      'callFrameId': '{"ordinal":0,"injectedScriptId":1}',
+      'callFrameId': session.pausedDetails().callFrames[0].callFrameId,
       'expression': 'k + t',
       'objectGroup': 'console',
       'includeCommandLineAPI': true,
@@ -150,7 +150,7 @@ async function testI18NCharacters(session) {
   const chars = 'טֶ字и';
   session.send({
     'method': 'Debugger.evaluateOnCallFrame', 'params': {
-      'callFrameId': '{"ordinal":0,"injectedScriptId":1}',
+      'callFrameId': session.pausedDetails().callFrames[0].callFrameId,
       'expression': `console.log("${chars}")`,
       'objectGroup': 'console',
       'includeCommandLineAPI': true,
@@ -276,7 +276,7 @@ async function testCommandLineAPI(session) {
   result = await session.send(
     {
       'method': 'Debugger.evaluateOnCallFrame', 'params': {
-        'callFrameId': '{"ordinal":0,"injectedScriptId":1}',
+        'callFrameId': session.pausedDetails().callFrames[0].callFrameId,
         'expression': `(
           require(${printBModuleStr}),
           require.cache[${printBModuleStr}].parent.id


### PR DESCRIPTION
**Note**: this has been already committed to upstream node: https://github.com/nodejs/node/pull/35570.

Relevant V8 CL: https://chromium-review.googlesource.com/c/v8/v8/+/2461731

---

Debugger.CallFrameId is defined as an opaque string [1].

Some tests currently hardcode the value, relying on
undocumented internal details of V8. This makes it hard
for V8 to change the internal representation.

We should instead use the reported call frame id from
the Debugger.paused event directly. This is how every
inspector client does it.

[1] https://chromedevtools.github.io/devtools-protocol/tot/Debugger/#type-CallFrameId
