### PR TITLE
test: Make two strings longer in test-fs-write.js

### DIFF
--- a/test/parallel/test-fs-write.js
+++ b/test/parallel/test-fs-write.js
@@ -60,7 +60,7 @@ common.allowGlobals(externalizeString, isOneByteString, x);
 }
 
 {
-  const expected = '中文 1';  // Must be a unique string.
+  const expected = '中文中文 1';  // Must be a unique string.
   externalizeString(expected);
   assert.strictEqual(isOneByteString(expected), false);
   const fd = fs.openSync(fn, 'w');
@@ -70,7 +70,7 @@ common.allowGlobals(externalizeString, isOneByteString, x);
 }
 
 {
-  const expected = '中文 2';  // Must be a unique string.
+  const expected = '中文中文 2';  // Must be a unique string.
   externalizeString(expected);
   assert.strictEqual(isOneByteString(expected), false);
   const fd = fs.openSync(fn, 'w');


### PR DESCRIPTION
We have some changes in V8 regarding internal & external & uncached
strings. By making them bigger, we are making them internal &
external & not uncached (i.e. cached).

Refs: https://chromium-review.googlesource.com/c/v8/v8/+/2565511

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
