### PR TITLE
Disable Proxy test in parallel/test-v8-serdes.js

### DIFF
--- a/test/parallel/test-v8-serdes.js
+++ b/test/parallel/test-v8-serdes.js
@@ -51,6 +51,9 @@ const deserializerTypeError =
   }
 }
 
+/*
+// Disable the following test while https://chromium-review.googlesource.com/c/v8/v8/+/2739980 is being merged
+// After merging, a follow-up PR will be made to re-enable this test with changed behavior
 {
   const ser = new v8.DefaultSerializer();
   ser._getDataCloneError = common.mustCall((message) => {
@@ -64,6 +67,7 @@ const deserializerTypeError =
     ser.writeValue(new Proxy({}, {}));
   }, /foobar/);
 }
+*/
 
 {
   const ser = new v8.DefaultSerializer();


### PR DESCRIPTION
This PR disables the Proxy test in test/parallel/test-v8-serdes.js while https://chromium-review.googlesource.com/c/v8/v8/+/2739980 is being merged.

Will do another PR to re-enabled the (fixed) test once the 2739980 has landed.

CC @LeszekSwirski