### PR TITLE
[#11570] Disable Proxy test in parallel/test-v8-serdes.js

### DIFF
--- a/test/parallel/test-v8-serdes.js
+++ b/test/parallel/test-v8-serdes.js
@@ -46,23 +46,25 @@ const hostObject = new (internalBinding('js_stream').JSStream)();
   }
 }
 
-/*
-// TODO(v8:11570): We disable the following test, while https://chromium-review.googlesource.com/c/v8/v8/+/2739980 is being merged
-// After merging, a follow-up PR will be made to re-enable this test with changed behavior
-{
-  const ser = new v8.DefaultSerializer();
-  ser._getDataCloneError = common.mustCall((message) => {
-    assert.strictEqual(message, '[object Object] could not be cloned.');
-    return new Error('foobar');
-  });
-
-  ser.writeHeader();
-
-  assert.throws(() => {
-    ser.writeValue(new Proxy({}, {}));
-  }, /foobar/);
-}
-*/
+// TODO(v8:11570): We disable the following test, while patch
+// 2739980 is being merged
+// After merging, a follow-up PR will be made to re-enable this test
+// with changed behavior
+//
+// {
+// const ser = new v8.DefaultSerializer();
+// ser._getDataCloneError = common.mustCall((message) => {
+//     assert.strictEqual(message, '[object Object] could not be cloned.');
+//     return new Error('foobar');
+// });
+//
+// ser.writeHeader();
+//
+// assert.throws(() => {
+//     ser.writeValue(new Proxy({}, {}));
+// }, /foobar/);
+// }
+//
 
 {
   const ser = new v8.DefaultSerializer();

--- a/test/parallel/test-v8-serdes.js
+++ b/test/parallel/test-v8-serdes.js
@@ -46,6 +46,9 @@ const hostObject = new (internalBinding('js_stream').JSStream)();
   }
 }
 
+/*
+// TODO(v8:11570): We disable the following test, while https://chromium-review.googlesource.com/c/v8/v8/+/2739980 is being merged
+// After merging, a follow-up PR will be made to re-enable this test with changed behavior
 {
   const ser = new v8.DefaultSerializer();
   ser._getDataCloneError = common.mustCall((message) => {
@@ -59,6 +62,7 @@ const hostObject = new (internalBinding('js_stream').JSStream)();
     ser.writeValue(new Proxy({}, {}));
   }, /foobar/);
 }
+*/
 
 {
   const ser = new v8.DefaultSerializer();


### PR DESCRIPTION
See: https://bugs.chromium.org/p/v8/issues/detail?id=11570

This PR disables the Proxy test in test/parallel/test-v8-serdes.js while https://chromium-review.googlesource.com/c/v8/v8/+/2739980 is being merged.

I will create another PR to re-enable the (fixed) test once the 2739980 has landed.

This PR supersedes https://github.com/v8/node/pull/124

CC @victorgomes