### PR TITLE
[test] Temporarily disable test/parallel/test-trace-events-{all,v8}

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -22,6 +22,10 @@ test-tick-processor-arguments: SKIP
 # Skip tests failing in V8 bots when updating Node
 test-child-process-stdio-overlapped: SKIP
 
+# Temporarily skip for https://crrev.com/c/3487548
+test-trace-events-all: SKIP
+test-trace-events-v8: SKIP
+
 # Temporarily skip for https://crrev.com/c/2974772
 test-util-inspect: SKIP
 


### PR DESCRIPTION
These two tests check for the event `V8.GCScavenger`, to ensure that V8 trace events are generated. This event is about to be deprecated. A [PR](https://github.com/nodejs/node/pull/42120) has been created for this in nodejs/node.