### PR TITLE
[test] Re-enable test/parallel/test-trace-events-{all,v8}

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -22,10 +22,6 @@ test-tick-processor-arguments: SKIP
 # Skip tests failing in V8 bots when updating Node
 test-child-process-stdio-overlapped: SKIP
 
-# Temporarily skip for https://crrev.com/c/3487548
-test-trace-events-all: SKIP
-test-trace-events-v8: SKIP
-
 # Temporarily skip for https://crrev.com/c/2974772
 test-util-inspect: SKIP
 


### PR DESCRIPTION
These two tests were [temporarily disabled](https://github.com/v8/node/pull/137), when V8.GCScavenger was [deprecated](https://crrev.com/c/3487548). After [this PR](https://github.com/nodejs/node/pull/42120) was merged in nodejs and rolled, disabling them is no more necessary.