### PR TITLE
[upstream:v8.10.3] Fix ContextifyContext::PropertySetterCallback()

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -459,6 +459,7 @@ void ContextifyContext::PropertySetterCallback(
   }
 
   USE(ctx->sandbox()->Set(context, property, value));
+  args.GetReturnValue().Set(true);
 }
 
 // static


### PR DESCRIPTION
... which must return result if the request was intercepted.