### PR TITLE
Disable freezing V8 flags on initialization

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -910,6 +910,11 @@ int InitializeNodeWithArgs(std::vector<std::string>* argv,
   // used in diagnostic reports.
   per_process::cli_options->cmdline = *argv;
 
+  // Node provides a "v8.setFlagsFromString" method to dynamically change flags.
+  // Hence do not freeze flags when initializing V8. In a browser setting, this
+  // is security relevant, for Node it's less important.
+  V8::SetFlagsFromString("--no-freeze-flags-after-init");
+
 #if defined(NODE_V8_OPTIONS)
   // Should come before the call to V8::SetFlagsFromCommandLine()
   // so the user can disable a flag --foo at run-time by passing

--- a/test/cctest/node_test_fixture.cc
+++ b/test/cctest/node_test_fixture.cc
@@ -24,6 +24,11 @@ void NodeTestEnvironment::SetUp() {
 #endif
   cppgc::InitializeProcess(
       NodeZeroIsolateTestFixture::platform->GetPageAllocator());
+
+  // Before initializing V8, disable the --freeze-flags-after-init flag, so
+  // individual tests can set their own flags.
+  v8::V8::SetFlagsFromString("--no-freeze-flags-after-init");
+
   v8::V8::Initialize();
 }
 

--- a/tools/code_cache/mkcodecache.cc
+++ b/tools/code_cache/mkcodecache.cc
@@ -29,6 +29,8 @@ int main(int argc, char* argv[]) {
 
   v8::V8::SetFlagsFromString("--random_seed=42");
   v8::V8::SetFlagsFromString("--harmony-import-assertions");
+  // Do not freeze flags so we can later reset the random seed.
+  v8::V8::SetFlagsFromString("--no-freeze-flags-after-init");
 
   if (argc < 2) {
     std::cerr << "Usage: " << argv[0] << " <path/to/output.cc>\n";


### PR DESCRIPTION
Node still changes flags after initializationg; either because tests
need to set their own flags (which V8 tests also still allow), or
because it's explicitly requested via the "v8.setFlagsFromString" method
that Node provides.