### PR TITLE
[platform] Override CreateJob instead of PostJob

### DIFF
--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -518,8 +518,8 @@ bool NodePlatform::FlushForegroundTasks(Isolate* isolate) {
   return per_isolate->FlushForegroundTasksInternal();
 }
 
-std::unique_ptr<v8::JobHandle> NodePlatform::PostJob(v8::TaskPriority priority,
-                                       std::unique_ptr<v8::JobTask> job_task) {
+std::unique_ptr<v8::JobHandle> NodePlatform::CreateJob(
+    v8::TaskPriority priority, std::unique_ptr<v8::JobTask> job_task) {
   return v8::platform::NewDefaultJobHandle(
       this, priority, std::move(job_task), NumberOfWorkerThreads());
 }

--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -155,7 +155,7 @@ class NodePlatform : public MultiIsolatePlatform {
   double CurrentClockTimeMillis() override;
   v8::TracingController* GetTracingController() override;
   bool FlushForegroundTasks(v8::Isolate* isolate) override;
-  std::unique_ptr<v8::JobHandle> PostJob(
+  std::unique_ptr<v8::JobHandle> CreateJob(
       v8::TaskPriority priority,
       std::unique_ptr<v8::JobTask> job_task) override;
 


### PR DESCRIPTION
PostJob will call out to CreateJob in its default implementation, so
it's sufficient to only override CreateJob.

The default implementation of CreateJob will return a nullptr though, so
we cannot use it in V8 before Node overrides it.