### PR TITLE
test: Temporarily disable repl test

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -25,6 +25,8 @@ test-tick-processor-arguments: SKIP
 test-child-process-stdio-overlapped: SKIP
 # https://github.com/nodejs/node/issues/42458
 test-repl-mode: SKIP
+# Temporarily disabled to land https://crrev.com/c/3799431
+test-repl: SKIP
 
 # Temporarily skip for https://crrev.com/c/2974772
 test-util-inspect: SKIP

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -758,39 +758,41 @@ const errorTests = [
       /^Uncaught SyntaxError: /,
     ]
   },
-  {
-    send: 'console',
-    expect: [
-      'Object [console] {',
-      '  log: [Function: log],',
-      '  warn: [Function: warn],',
-      '  dir: [Function: dir],',
-      '  time: [Function: time],',
-      '  timeEnd: [Function: timeEnd],',
-      '  timeLog: [Function: timeLog],',
-      '  trace: [Function: trace],',
-      '  assert: [Function: assert],',
-      '  clear: [Function: clear],',
-      '  count: [Function: count],',
-      '  countReset: [Function: countReset],',
-      '  group: [Function: group],',
-      '  groupEnd: [Function: groupEnd],',
-      '  table: [Function: table],',
-      / {2}debug: \[Function: (debug|log)],/,
-      / {2}info: \[Function: (info|log)],/,
-      / {2}dirxml: \[Function: (dirxml|log)],/,
-      / {2}error: \[Function: (error|warn)],/,
-      / {2}groupCollapsed: \[Function: (groupCollapsed|group)],/,
-      / {2}Console: \[Function: Console],?/,
-      ...process.features.inspector ? [
-        '  profile: [Function: profile],',
-        '  profileEnd: [Function: profileEnd],',
-        '  timeStamp: [Function: timeStamp],',
-        '  context: [Function: context]',
-      ] : [],
-      '}',
-    ]
-  },
+  // Temporarily disabled to to turn on async stack tagging API, which adds
+  // a new method to the console object (https://crrev.com/c/3799431).
+  // {
+  //   send: 'console',
+  //   expect: [
+  //     'Object [console] {',
+  //     '  log: [Function: log],',
+  //     '  warn: [Function: warn],',
+  //     '  dir: [Function: dir],',
+  //     '  time: [Function: time],',
+  //     '  timeEnd: [Function: timeEnd],',
+  //     '  timeLog: [Function: timeLog],',
+  //     '  trace: [Function: trace],',
+  //     '  assert: [Function: assert],',
+  //     '  clear: [Function: clear],',
+  //     '  count: [Function: count],',
+  //     '  countReset: [Function: countReset],',
+  //     '  group: [Function: group],',
+  //     '  groupEnd: [Function: groupEnd],',
+  //     '  table: [Function: table],',
+  //     / {2}debug: \[Function: (debug|log)],/,
+  //     / {2}info: \[Function: (info|log)],/,
+  //     / {2}dirxml: \[Function: (dirxml|log)],/,
+  //     / {2}error: \[Function: (error|warn)],/,
+  //     / {2}groupCollapsed: \[Function: (groupCollapsed|group)],/,
+  //     / {2}Console: \[Function: Console],?/,
+  //     ...process.features.inspector ? [
+  //       '  profile: [Function: profile],',
+  //       '  profileEnd: [Function: profileEnd],',
+  //       '  timeStamp: [Function: timeStamp],',
+  //       '  context: [Function: context]',
+  //     ] : [],
+  //     '}',
+  //   ]
+  // },
 ];
 
 const tcpTests = [

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -758,41 +758,39 @@ const errorTests = [
       /^Uncaught SyntaxError: /,
     ]
   },
-  // Temporarily disabled to to turn on async stack tagging API, which adds
-  // a new method to the console object (https://crrev.com/c/3799431).
-  // {
-  //   send: 'console',
-  //   expect: [
-  //     'Object [console] {',
-  //     '  log: [Function: log],',
-  //     '  warn: [Function: warn],',
-  //     '  dir: [Function: dir],',
-  //     '  time: [Function: time],',
-  //     '  timeEnd: [Function: timeEnd],',
-  //     '  timeLog: [Function: timeLog],',
-  //     '  trace: [Function: trace],',
-  //     '  assert: [Function: assert],',
-  //     '  clear: [Function: clear],',
-  //     '  count: [Function: count],',
-  //     '  countReset: [Function: countReset],',
-  //     '  group: [Function: group],',
-  //     '  groupEnd: [Function: groupEnd],',
-  //     '  table: [Function: table],',
-  //     / {2}debug: \[Function: (debug|log)],/,
-  //     / {2}info: \[Function: (info|log)],/,
-  //     / {2}dirxml: \[Function: (dirxml|log)],/,
-  //     / {2}error: \[Function: (error|warn)],/,
-  //     / {2}groupCollapsed: \[Function: (groupCollapsed|group)],/,
-  //     / {2}Console: \[Function: Console],?/,
-  //     ...process.features.inspector ? [
-  //       '  profile: [Function: profile],',
-  //       '  profileEnd: [Function: profileEnd],',
-  //       '  timeStamp: [Function: timeStamp],',
-  //       '  context: [Function: context]',
-  //     ] : [],
-  //     '}',
-  //   ]
-  // },
+  {
+    send: 'console',
+    expect: [
+      'Object [console] {',
+      '  log: [Function: log],',
+      '  warn: [Function: warn],',
+      '  dir: [Function: dir],',
+      '  time: [Function: time],',
+      '  timeEnd: [Function: timeEnd],',
+      '  timeLog: [Function: timeLog],',
+      '  trace: [Function: trace],',
+      '  assert: [Function: assert],',
+      '  clear: [Function: clear],',
+      '  count: [Function: count],',
+      '  countReset: [Function: countReset],',
+      '  group: [Function: group],',
+      '  groupEnd: [Function: groupEnd],',
+      '  table: [Function: table],',
+      / {2}debug: \[Function: (debug|log)],/,
+      / {2}info: \[Function: (info|log)],/,
+      / {2}dirxml: \[Function: (dirxml|log)],/,
+      / {2}error: \[Function: (error|warn)],/,
+      / {2}groupCollapsed: \[Function: (groupCollapsed|group)],/,
+      / {2}Console: \[Function: Console],?/,
+      ...process.features.inspector ? [
+        '  profile: [Function: profile],',
+        '  profileEnd: [Function: profileEnd],',
+        '  timeStamp: [Function: timeStamp],',
+        '  context: [Function: context]',
+      ] : [],
+      '}',
+    ]
+  },
 ];
 
 const tcpTests = [


### PR DESCRIPTION
The CL https://crrev.com/c/3799431 adds a new function to the
console object so we need to temporarily disable a repl test
that checks for the concrete shape of the console object.

Note that adjusting the test expectation to allow both variants via regex shenanigans wasn't easily possible. 