### PR TITLE
Update deprecated V8 APIs

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -219,7 +219,8 @@ class ChannelImpl final : public v8_inspector::V8Inspector::Channel,
                        bool prevent_shutdown)
       : delegate_(std::move(delegate)), prevent_shutdown_(prevent_shutdown),
         retaining_context_(false) {
-    session_ = inspector->connect(CONTEXT_GROUP_ID, this, StringView());
+    session_ = inspector->connect(
+        CONTEXT_GROUP_ID, this, StringView(), V8Inspector::kFullyTrusted);
     node_dispatcher_ = std::make_unique<protocol::UberDispatcher>(this);
     tracing_agent_ =
         std::make_unique<protocol::TracingAgent>(env, main_thread_);

--- a/src/node_native_module.cc
+++ b/src/node_native_module.cc
@@ -284,13 +284,13 @@ MaybeLocal<Function> NativeModuleLoader::LookupAndCompile(
                      has_cache ? "with" : "without");
 
   MaybeLocal<Function> maybe_fun =
-      ScriptCompiler::CompileFunctionInContext(context,
-                                               &script_source,
-                                               parameters->size(),
-                                               parameters->data(),
-                                               0,
-                                               nullptr,
-                                               options);
+      ScriptCompiler::CompileFunction(context,
+                                      &script_source,
+                                      parameters->size(),
+                                      parameters->data(),
+                                      0,
+                                      nullptr,
+                                      options);
 
   // This could fail when there are early errors in the native modules,
   // e.g. the syntax errors

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -487,13 +487,13 @@ void CompileSerializeMain(const FunctionCallbackInfo<Value>& args) {
   };
   ScriptCompiler::Source script_source(source, origin);
   Local<Function> fn;
-  if (ScriptCompiler::CompileFunctionInContext(context,
-                                               &script_source,
-                                               parameters.size(),
-                                               parameters.data(),
-                                               0,
-                                               nullptr,
-                                               ScriptCompiler::kEagerCompile)
+  if (ScriptCompiler::CompileFunction(context,
+                                      &script_source,
+                                      parameters.size(),
+                                      parameters.data(),
+                                      0,
+                                      nullptr,
+                                      ScriptCompiler::kEagerCompile)
           .ToLocal(&fn)) {
     args.GetReturnValue().Set(fn);
   }


### PR DESCRIPTION
- Update inspector functions
- Use ScriptCompiler::CompileFunction instead of ScriptCompiler::CompileFunctionInContext where possible