### PR TITLE
[tests] Accept `step` break message

### DIFF
--- a/test/common/debugger.js
+++ b/test/common/debugger.js
@@ -4,7 +4,7 @@ const spawn = require('child_process').spawn;
 
 const BREAK_MESSAGE = new RegExp('(?:' + [
   'assert', 'break', 'break on start', 'debugCommand',
-  'exception', 'other', 'promiseRejection',
+  'exception', 'other', 'promiseRejection', 'step',
 ].join('|') + ') in', 'i');
 
 let TIMEOUT = common.platformTimeout(5000);
@@ -121,13 +121,13 @@ function startCLI(args, flags = [], spawnOpts = {}) {
     get breakInfo() {
       const output = this.output;
       const breakMatch =
-        output.match(/break (?:on start )?in ([^\n]+):(\d+)\n/i);
+        output.match(/(step |break (?:on start )?)in ([^\n]+):(\d+)\n/i);
 
       if (breakMatch === null) {
         throw new Error(
           `Could not find breakpoint info in ${JSON.stringify(output)}`);
       }
-      return { filename: breakMatch[1], line: +breakMatch[2] };
+      return { filename: breakMatch[2], line: +breakMatch[3] };
     },
 
     ctrlC() {

--- a/test/sequential/test-debugger-break.js
+++ b/test/sequential/test-debugger-break.js
@@ -27,7 +27,7 @@ const cli = startCLI([script]);
 
   await cli.stepCommand('n');
   assert.ok(
-    cli.output.includes(`break in ${script}:2`),
+    cli.output.includes(`step in ${script}:2`),
     'pauses in next line of the script');
   assert.match(
     cli.output,
@@ -36,7 +36,7 @@ const cli = startCLI([script]);
 
   await cli.stepCommand('next');
   assert.ok(
-    cli.output.includes(`break in ${script}:3`),
+    cli.output.includes(`step in ${script}:3`),
     'pauses in next line of the script');
   assert.match(
     cli.output,
@@ -89,7 +89,7 @@ const cli = startCLI([script]);
   await cli.stepCommand('');
   assert.match(
     cli.output,
-    /break in node:timers/,
+    /step in node:timers/,
     'entered timers.js');
 
   await cli.stepCommand('cont');

--- a/test/sequential/test-debugger-run-after-quit-restart.js
+++ b/test/sequential/test-debugger-run-after-quit-restart.js
@@ -25,7 +25,7 @@ const path = require('path');
     .then(() => cli.stepCommand('n'))
     .then(() => {
       assert.ok(
-        cli.output.includes(`break in ${script}:2`),
+        cli.output.includes(`step in ${script}:2`),
         'steps to the 2nd line'
       );
     })


### PR DESCRIPTION
After stepping v8 is reporting an explicit `step` reason on pause now. Fix the tests.