### PR TITLE
Skip test depending on always-true removed --harmony-atomics flag

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -28,6 +28,9 @@ test-repl-mode: SKIP
 # Temporarily disabled to land https://crrev.com/c/3799431
 test-repl: SKIP
 
+# Skip test depending on always-true removed --harmony-atomics flag
+test-worker-no-atomics: SKIP
+
 # Temporarily skip for https://crrev.com/c/2974772
 test-util-inspect: SKIP
 


### PR DESCRIPTION
The failing test is a regression test for https://github.com/nodejs/node/issues/39717, which is about a crash that occurs when the flag is disabled. Given that that will no longer be possible once the flag is gone, this seems safe to disable forever.