### PR TITLE
Skip test-worker-no-sab

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -28,8 +28,9 @@ test-repl-mode: SKIP
 # Temporarily disabled to land https://crrev.com/c/3799431
 test-repl: SKIP
 
-# Skip test depending on always-true removed --harmony-atomics flag
+# Skip tests depending on removed feature flags for SAB and Atomics
 test-worker-no-atomics: SKIP
+test-worker-no-sab: SKIP
 
 # Temporarily skip for https://crrev.com/c/2974772
 test-util-inspect: SKIP


### PR DESCRIPTION
This test depends on the --harmony-sharedarraybuffer flag, which is always true and will be removed.
Since the test is a regression test for https://github.com/nodejs/node/issues/39717, about the repl crashing
when SABs are disabled, skipping the test unconditionally seems appropriate here.