### PR TITLE
Adapt tests for increased TypedArray sizes

### DIFF
--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -6,13 +6,6 @@ const vm = require('vm');
 
 const SlowBuffer = require('buffer').SlowBuffer;
 
-// Verify the maximum Uint8Array size. There is no concrete limit by spec. The
-// internal limits should be updated if this fails.
-assert.throws(
-  () => new Uint8Array(2 ** 32 + 1),
-  { message: 'Invalid typed array length: 4294967297' }
-);
-
 const b = Buffer.allocUnsafe(1024);
 assert.strictEqual(b.length, 1024);
 

--- a/test/parallel/test-buffer-over-max-length.js
+++ b/test/parallel/test-buffer-over-max-length.js
@@ -12,18 +12,8 @@ const bufferMaxSizeMsg = {
   name: 'RangeError',
 };
 
-assert.throws(() => Buffer((-1 >>> 0) + 2), bufferMaxSizeMsg);
-assert.throws(() => SlowBuffer((-1 >>> 0) + 2), bufferMaxSizeMsg);
-assert.throws(() => Buffer.alloc((-1 >>> 0) + 2), bufferMaxSizeMsg);
-assert.throws(() => Buffer.allocUnsafe((-1 >>> 0) + 2), bufferMaxSizeMsg);
-assert.throws(() => Buffer.allocUnsafeSlow((-1 >>> 0) + 2), bufferMaxSizeMsg);
-
 assert.throws(() => Buffer(kMaxLength + 1), bufferMaxSizeMsg);
 assert.throws(() => SlowBuffer(kMaxLength + 1), bufferMaxSizeMsg);
 assert.throws(() => Buffer.alloc(kMaxLength + 1), bufferMaxSizeMsg);
 assert.throws(() => Buffer.allocUnsafe(kMaxLength + 1), bufferMaxSizeMsg);
 assert.throws(() => Buffer.allocUnsafeSlow(kMaxLength + 1), bufferMaxSizeMsg);
-
-// issue GH-4331
-assert.throws(() => Buffer.allocUnsafe(0x100000001), bufferMaxSizeMsg);
-assert.throws(() => Buffer.allocUnsafe(0xFFFFFFFFF), bufferMaxSizeMsg);

--- a/test/parallel/test-buffer-tostring-rangeerror.js
+++ b/test/parallel/test-buffer-tostring-rangeerror.js
@@ -8,13 +8,23 @@ require('../common');
 const assert = require('assert');
 const SlowBuffer = require('buffer').SlowBuffer;
 
-const len = 1422561062959;
+// Find the maximum supported buffer length.
+let limit = 1 << 31; // 2GB
+while (true) {
+  try {
+    Buffer(limit);
+    limit *= 2;
+  } catch (e) {
+    break;
+  }
+}
+
 const message = {
   code: 'ERR_OUT_OF_RANGE',
   name: 'RangeError',
 };
-assert.throws(() => Buffer(len).toString('utf8'), message);
-assert.throws(() => SlowBuffer(len).toString('utf8'), message);
-assert.throws(() => Buffer.alloc(len).toString('utf8'), message);
-assert.throws(() => Buffer.allocUnsafe(len).toString('utf8'), message);
-assert.throws(() => Buffer.allocUnsafeSlow(len).toString('utf8'), message);
+assert.throws(() => Buffer(limit).toString('utf8'), message);
+assert.throws(() => SlowBuffer(limit).toString('utf8'), message);
+assert.throws(() => Buffer.alloc(limit).toString('utf8'), message);
+assert.throws(() => Buffer.allocUnsafe(limit).toString('utf8'), message);
+assert.throws(() => Buffer.allocUnsafeSlow(limit).toString('utf8'), message);


### PR DESCRIPTION
V8 will increase the maximum TypedArray size in
https://crrev.com/c/4872536; this CL adapts the tests to allow for that.

Tests that hard-code smaller sizes or are already tested in V8 are removed; one test is adapted to not rely on a specific limit.
