### PR TITLE
Migrate SetAccessor uses to SetNativeDataProperty

### DIFF
--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -591,35 +591,32 @@ void BuiltinLoader::Initialize(Local<Object> target,
   Isolate* isolate = env->isolate();
 
   target
-      ->SetAccessor(context,
-                    env->config_string(),
-                    ConfigStringGetter,
-                    nullptr,
-                    MaybeLocal<Value>(),
-                    DEFAULT,
-                    None,
-                    SideEffectType::kHasNoSideEffect)
+      ->SetNativeDataProperty(context,
+                              env->config_string(),
+                              ConfigStringGetter,
+                              nullptr,
+                              MaybeLocal<Value>(),
+                              None,
+                              SideEffectType::kHasNoSideEffect)
       .Check();
   target
-      ->SetAccessor(context,
-                    FIXED_ONE_BYTE_STRING(isolate, "builtinIds"),
-                    BuiltinIdsGetter,
-                    nullptr,
-                    MaybeLocal<Value>(),
-                    DEFAULT,
-                    None,
-                    SideEffectType::kHasNoSideEffect)
+      ->SetNativeDataProperty(context,
+                              FIXED_ONE_BYTE_STRING(isolate, "builtinIds"),
+                              BuiltinIdsGetter,
+                              nullptr,
+                              MaybeLocal<Value>(),
+                              None,
+                              SideEffectType::kHasNoSideEffect)
       .Check();
 
   target
-      ->SetAccessor(context,
-                    FIXED_ONE_BYTE_STRING(isolate, "builtinCategories"),
-                    GetBuiltinCategories,
-                    nullptr,
-                    Local<Value>(),
-                    DEFAULT,
-                    None,
-                    SideEffectType::kHasNoSideEffect)
+      ->SetNativeDataProperty(context,
+                              FIXED_ONE_BYTE_STRING(isolate, "builtinCategories"),
+                              GetBuiltinCategories,
+                              nullptr,
+                              Local<Value>(),
+                              None,
+                              SideEffectType::kHasNoSideEffect)
       .Check();
 
   SetMethod(context, target, "getCacheUsage", BuiltinLoader::GetCacheUsage);

--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -609,15 +609,14 @@ void BuiltinLoader::Initialize(Local<Object> target,
                               SideEffectType::kHasNoSideEffect)
       .Check();
 
-  target
-      ->SetNativeDataProperty(context,
-                              FIXED_ONE_BYTE_STRING(isolate, "builtinCategories"),
-                              GetBuiltinCategories,
-                              nullptr,
-                              Local<Value>(),
-                              None,
-                              SideEffectType::kHasNoSideEffect)
-      .Check();
+  target->SetNativeDataProperty(
+      context,
+      FIXED_ONE_BYTE_STRING(isolate, "builtinCategories"),
+      GetBuiltinCategories,
+      nullptr,
+      Local<Value>(),
+      None,
+      SideEffectType::kHasNoSideEffect).Check();
 
   SetMethod(context, target, "getCacheUsage", BuiltinLoader::GetCacheUsage);
   SetMethod(context, target, "compileFunction", BuiltinLoader::CompileFunction);

--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -9,7 +9,6 @@ namespace node {
 namespace builtins {
 
 using v8::Context;
-using v8::DEFAULT;
 using v8::EscapableHandleScope;
 using v8::Function;
 using v8::FunctionCallbackInfo;

--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -608,14 +608,16 @@ void BuiltinLoader::Initialize(Local<Object> target,
                               SideEffectType::kHasNoSideEffect)
       .Check();
 
-  target->SetNativeDataProperty(
-      context,
-      FIXED_ONE_BYTE_STRING(isolate, "builtinCategories"),
-      GetBuiltinCategories,
-      nullptr,
-      Local<Value>(),
-      None,
-      SideEffectType::kHasNoSideEffect).Check();
+  target
+      ->SetNativeDataProperty(
+          context,
+          FIXED_ONE_BYTE_STRING(isolate, "builtinCategories"),
+          GetBuiltinCategories,
+          nullptr,
+          Local<Value>(),
+          None,
+          SideEffectType::kHasNoSideEffect)
+      .Check();
 
   SetMethod(context, target, "getCacheUsage", BuiltinLoader::GetCacheUsage);
   SetMethod(context, target, "compileFunction", BuiltinLoader::CompileFunction);


### PR DESCRIPTION
SetAccessor creates a deprecated type of "native data property", which has been replaced by SetNativeDataProperty. The old mechanism for installing such properties took in an AccessControl that's been deprecated (node used DEFAULT anyway).