### PR TITLE
Avoid deprecated TypedArray::kMaxLength field

### DIFF
--- a/src/node_buffer.h
+++ b/src/node_buffer.h
@@ -29,7 +29,7 @@ namespace node {
 
 namespace Buffer {
 
-static const size_t kMaxLength = v8::TypedArray::kMaxLength;
+static const size_t kMaxLength = v8::TypedArray::kMaxByteLength;
 
 typedef void (*FreeCallback)(char* data, void* hint);
 

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -212,7 +212,7 @@ inline v8::Local<v8::Value> ERR_BUFFER_TOO_LARGE(v8::Isolate* isolate) {
   char message[128];
   snprintf(message, sizeof(message),
       "Cannot create a Buffer larger than 0x%zx bytes",
-      v8::TypedArray::kMaxLength);
+      v8::TypedArray::kMaxByteLength);
   return ERR_BUFFER_TOO_LARGE(isolate, message);
 }
 


### PR DESCRIPTION
Use TypedArray::kMaxByteLength instead.
