### PR TITLE
Add missing TryCatch

### DIFF
--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -162,6 +162,7 @@ void JSStream::Finish(const FunctionCallbackInfo<Value>& args) {
 
 
 void JSStream::ReadBuffer(const FunctionCallbackInfo<Value>& args) {
+  v8::TryCatch try_catch(args.GetIsolate());
   JSStream* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
 
@@ -182,6 +183,7 @@ void JSStream::ReadBuffer(const FunctionCallbackInfo<Value>& args) {
     len -= static_cast<int>(avail);
     wrap->EmitRead(avail, buf);
   }
+  if (try_catch.HasCaught()) try_catch.ReThrow();
 }
 
 


### PR DESCRIPTION
Otherwise re-entering v8 doesn't work as expected after exceptions were thrown.