### PR TITLE
Don't use soon-to-be-deprecated V8 Api

### DIFF
--- a/src/base_object-inl.h
+++ b/src/base_object-inl.h
@@ -132,14 +132,14 @@ v8::EmbedderGraph::Node::Detachedness BaseObject::GetDetachedness() const {
 
 template <int Field>
 void BaseObject::InternalFieldGet(
-    v8::Local<v8::String> property,
+    v8::Local<v8::Name> property,
     const v8::PropertyCallbackInfo<v8::Value>& info) {
   info.GetReturnValue().Set(
       info.This()->GetInternalField(Field).As<v8::Value>());
 }
 
 template <int Field, bool (v8::Value::* typecheck)() const>
-void BaseObject::InternalFieldSet(v8::Local<v8::String> property,
+void BaseObject::InternalFieldSet(v8::Local<v8::Name> property,
                                   v8::Local<v8::Value> value,
                                   const v8::PropertyCallbackInfo<void>& info) {
   // This could be e.g. value->IsFunction().

--- a/src/base_object.h
+++ b/src/base_object.h
@@ -111,10 +111,10 @@ class BaseObject : public MemoryRetainer {
 
   // Setter/Getter pair for internal fields that can be passed to SetAccessor.
   template <int Field>
-  static void InternalFieldGet(v8::Local<v8::String> property,
+  static void InternalFieldGet(v8::Local<v8::Name> property,
                                const v8::PropertyCallbackInfo<v8::Value>& info);
   template <int Field, bool (v8::Value::*typecheck)() const>
-  static void InternalFieldSet(v8::Local<v8::String> property,
+  static void InternalFieldSet(v8::Local<v8::Name> property,
                                v8::Local<v8::Value> value,
                                const v8::PropertyCallbackInfo<void>& info);
 

--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -57,8 +57,6 @@ class ExternalReferenceRegistry {
   V(CFunctionWithBool)                                                         \
   V(const v8::CFunctionInfo*)                                                  \
   V(v8::FunctionCallback)                                                      \
-  V(v8::AccessorGetterCallback)                                                \
-  V(v8::AccessorSetterCallback)                                                \
   V(v8::AccessorNameGetterCallback)                                            \
   V(v8::AccessorNameSetterCallback)                                            \
   V(v8::GenericNamedPropertyDefinerCallback)                                   \


### PR DESCRIPTION
Namely `v8::ObjectTemplate::SetAccessor(v8::Local<v8::String>, ...);`
See https://crrev.com/c/v8/v8/+/5344409 for details.
