### PR TITLE
Add node_enable_deprecated_declarations_warnings GN flag

### DIFF
--- a/deps/openssl/unofficial.gni
+++ b/deps/openssl/unofficial.gni
@@ -16,6 +16,7 @@ template("openssl_gn_build") {
       "openssl/crypto/include",
       "openssl/include",
     ]
+    defines = [ "OPENSSL_API_COMPAT=0x10100001L" ]
   }
 
   config("openssl_internal_config") {
@@ -26,7 +27,6 @@ template("openssl_gn_build") {
 
     defines = [
       "MODULESDIR=\"deps/openssl/lib/openssl-modules\"",
-      "OPENSSL_API_COMPAT=0x10100001L",
       "STATIC_LEGACY",
     ] + gypi_values.openssl_default_defines_all
     if (is_win) {

--- a/unofficial.gni
+++ b/unofficial.gni
@@ -6,6 +6,12 @@ import("node.gni")
 import("$node_v8_path/gni/snapshot_toolchain.gni")
 import("$node_v8_path/gni/v8.gni")
 
+declare_args() {
+  # Enable warnings about usages of deprecated declarations and suppress
+  # known issues with c-ares.
+  node_enable_deprecated_declarations_warnings = false
+}
+
 # The actual configurations are put inside a template in unofficial.gni to
 # prevent accidental edits from contributors.
 template("node_gn_build") {
@@ -33,7 +39,7 @@ template("node_gn_build") {
       defines += [ "HAVE_INSPECTOR=0" ]
     }
     if (node_use_node_code_cache) {
-      defines += [ "NODE_USE_NODE_CODE_CACHE=1"]
+      defines += [ "NODE_USE_NODE_CODE_CACHE=1" ]
     }
     if (v8_enable_i18n_support) {
       defines += [ "NODE_HAVE_I18N_SUPPORT=1" ]
@@ -64,7 +70,6 @@ template("node_gn_build") {
     libs = []
     cflags = [ "-Wno-microsoft-include" ]
     cflags_cc = [
-      "-Wno-deprecated-declarations",
       "-Wno-extra-semi",
       "-Wno-implicit-fallthrough",
       "-Wno-macro-redefined",
@@ -81,6 +86,10 @@ template("node_gn_build") {
       "-Wno-unused-variable",
       "-Wno-unused-function",
     ]
+
+    if (!node_enable_deprecated_declarations_warnings) {
+      cflags_cc += [ "-Wno-deprecated-declarations" ]
+    }
 
     if (current_cpu == "x86") {
       node_arch = "ia32"
@@ -99,6 +108,10 @@ template("node_gn_build") {
       "NODE_PLATFORM=\"$node_platform\"",
       "NODE_REPORT"
     ]
+
+    if (node_enable_deprecated_declarations_warnings) {
+      defines += [ "CARES_NO_DEPRECATED=1" ]
+    }
 
     if (is_win) {
       defines += [

--- a/unofficial.gni
+++ b/unofficial.gni
@@ -110,7 +110,7 @@ template("node_gn_build") {
     ]
 
     if (node_enable_deprecated_declarations_warnings) {
-      // Refs: https://github.com/nodejs/node/issues/52464
+      # Refs: https://github.com/nodejs/node/issues/52464
       defines += [ "CARES_NO_DEPRECATED=1" ]
     }
 

--- a/unofficial.gni
+++ b/unofficial.gni
@@ -110,6 +110,7 @@ template("node_gn_build") {
     ]
 
     if (node_enable_deprecated_declarations_warnings) {
+      // Refs: https://github.com/nodejs/node/issues/52464
       defines += [ "CARES_NO_DEPRECATED=1" ]
     }
 


### PR DESCRIPTION
Warnings about using deprecated declarations were disabled by default which made it impossible to ensure that Node doesn't use V8's deprecated Apis - V8's node-ci bots just didn't complain.

The flag allows enabling deprecated warnings and suppresses known issue with using deprecated functionality in c-api (see https://github.com/nodejs/node/issues/52464).

The flag is off by default which preserves the existing behavior.

Drive-by: fix deps/openssl/unofficial.gni by exposing the required OpenSSL compatibility level (`OPENSSL_API_COMPAT`) via public_configs similarly to how it's done in gyp configs.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
