### PR TITLE
Don't use soon-to-be-deprecated V8 Api

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -923,7 +923,7 @@ void MyObject::New(const FunctionCallbackInfo<Value>& args) {
 void MyObject::PlusOne(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
 
-  MyObject* obj = ObjectWrap::Unwrap<MyObject>(args.Holder());
+  MyObject* obj = ObjectWrap::Unwrap<MyObject>(args.This());
   obj->value_ += 1;
 
   args.GetReturnValue().Set(Number::New(isolate, obj->value_));
@@ -1138,7 +1138,7 @@ void MyObject::NewInstance(const FunctionCallbackInfo<Value>& args) {
 void MyObject::PlusOne(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
 
-  MyObject* obj = ObjectWrap::Unwrap<MyObject>(args.Holder());
+  MyObject* obj = ObjectWrap::Unwrap<MyObject>(args.This());
   obj->value_ += 1;
 
   args.GetReturnValue().Set(Number::New(isolate, obj->value_));

--- a/src/README.md
+++ b/src/README.md
@@ -418,8 +418,6 @@ Node.js source code.)
 
 `args[n]` is a `Local<Value>` that represents the n-th argument passed to the
 function. `args.This()` is the `this` value inside this function call.
-`args.Holder()` is equivalent to `args.This()` in all use cases inside of
-Node.js.
 
 `args.GetReturnValue()` is a placeholder for the return value of the function,
 and provides a `.Set()` method that can be called with a boolean, integer,
@@ -828,9 +826,9 @@ class from C++.
 The JavaScript object can be accessed as a `v8::Local<v8::Object>` by using
 `self->object()`, given a `BaseObject` named `self`.
 
-Accessing a `BaseObject` from a `v8::Local<v8::Object>` (frequently that is
-`args.This()` or `args.Holder()` in a [binding function][]) can be done using
-the `Unwrap<T>(obj)` function, where `T` is a subclass of `BaseObject`.
+Accessing a `BaseObject` from a `v8::Local<v8::Object>` (that is `args.This()`
+in a [binding function][]) can be done using the `Unwrap<T>(obj)` function,
+where `T` is a subclass of `BaseObject`.
 A helper for this is the `ASSIGN_OR_RETURN_UNWRAP` macro that returns from the
 current function if unwrapping fails (typically that means that the `BaseObject`
 has been deleted earlier).
@@ -838,7 +836,7 @@ has been deleted earlier).
 ```cpp
 void Http2Session::Request(const FunctionCallbackInfo<Value>& args) {
   Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&session, args.This());
   Environment* env = session->env();
   Local<Context> context = env->context();
   Isolate* isolate = env->isolate();

--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -248,7 +248,7 @@ static void RegisterDestroyHook(const FunctionCallbackInfo<Value>& args) {
 void AsyncWrap::GetAsyncId(const FunctionCallbackInfo<Value>& args) {
   AsyncWrap* wrap;
   args.GetReturnValue().Set(kInvalidAsyncId);
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
   args.GetReturnValue().Set(wrap->get_async_id());
 }
 
@@ -290,7 +290,7 @@ void AsyncWrap::AsyncReset(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsObject());
 
   AsyncWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
 
   Local<Object> resource = args[0].As<Object>();
   double execution_async_id =
@@ -302,7 +302,7 @@ void AsyncWrap::AsyncReset(const FunctionCallbackInfo<Value>& args) {
 void AsyncWrap::GetProviderType(const FunctionCallbackInfo<Value>& args) {
   AsyncWrap* wrap;
   args.GetReturnValue().Set(AsyncWrap::PROVIDER_NONE);
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
   args.GetReturnValue().Set(wrap->provider_type());
 }
 

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -1404,7 +1404,7 @@ template <class Wrap>
 static void Query(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   ChannelWrap* channel;
-  ASSIGN_OR_RETURN_UNWRAP(&channel, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&channel, args.This());
 
   CHECK_EQ(false, args.IsConstructCall());
   CHECK(args[0]->IsObject());
@@ -1664,7 +1664,7 @@ void GetNameInfo(const FunctionCallbackInfo<Value>& args) {
 void GetServers(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   ChannelWrap* channel;
-  ASSIGN_OR_RETURN_UNWRAP(&channel, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&channel, args.This());
 
   Local<Array> server_array = Array::New(env->isolate());
 
@@ -1702,7 +1702,7 @@ void GetServers(const FunctionCallbackInfo<Value>& args) {
 void SetServers(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   ChannelWrap* channel;
-  ASSIGN_OR_RETURN_UNWRAP(&channel, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&channel, args.This());
 
   if (channel->active_query_count()) {
     return args.GetReturnValue().Set(DNS_ESETSRVPENDING);
@@ -1783,7 +1783,7 @@ void SetServers(const FunctionCallbackInfo<Value>& args) {
 void SetLocalAddress(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   ChannelWrap* channel;
-  ASSIGN_OR_RETURN_UNWRAP(&channel, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&channel, args.This());
 
   CHECK_EQ(args.Length(), 2);
   CHECK(args[0]->IsString());
@@ -1846,7 +1846,7 @@ void SetLocalAddress(const FunctionCallbackInfo<Value>& args) {
 
 void Cancel(const FunctionCallbackInfo<Value>& args) {
   ChannelWrap* channel;
-  ASSIGN_OR_RETURN_UNWRAP(&channel, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&channel, args.This());
 
   TRACE_EVENT_INSTANT0(TRACING_CATEGORY_NODE2(dns, native),
       "cancel", TRACE_EVENT_SCOPE_THREAD);

--- a/src/crypto/crypto_cipher.cc
+++ b/src/crypto/crypto_cipher.cc
@@ -438,7 +438,7 @@ void CipherBase::Init(const char* cipher_type,
 
 void CipherBase::Init(const FunctionCallbackInfo<Value>& args) {
   CipherBase* cipher;
-  ASSIGN_OR_RETURN_UNWRAP(&cipher, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&cipher, args.This());
   Environment* env = Environment::GetCurrent(args);
 
   CHECK_GE(args.Length(), 3);
@@ -510,7 +510,7 @@ void CipherBase::InitIv(const char* cipher_type,
 
 void CipherBase::InitIv(const FunctionCallbackInfo<Value>& args) {
   CipherBase* cipher;
-  ASSIGN_OR_RETURN_UNWRAP(&cipher, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&cipher, args.This());
   Environment* env = cipher->env();
 
   CHECK_GE(args.Length(), 4);
@@ -645,7 +645,7 @@ bool CipherBase::IsAuthenticatedMode() const {
 void CipherBase::GetAuthTag(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   CipherBase* cipher;
-  ASSIGN_OR_RETURN_UNWRAP(&cipher, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&cipher, args.This());
 
   // Only callable after Final and if encrypting.
   if (cipher->ctx_ ||
@@ -661,7 +661,7 @@ void CipherBase::GetAuthTag(const FunctionCallbackInfo<Value>& args) {
 
 void CipherBase::SetAuthTag(const FunctionCallbackInfo<Value>& args) {
   CipherBase* cipher;
-  ASSIGN_OR_RETURN_UNWRAP(&cipher, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&cipher, args.This());
   Environment* env = Environment::GetCurrent(args);
 
   if (!cipher->ctx_ ||
@@ -774,7 +774,7 @@ bool CipherBase::SetAAD(
 
 void CipherBase::SetAAD(const FunctionCallbackInfo<Value>& args) {
   CipherBase* cipher;
-  ASSIGN_OR_RETURN_UNWRAP(&cipher, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&cipher, args.This());
   Environment* env = Environment::GetCurrent(args);
 
   CHECK_EQ(args.Length(), 2);
@@ -887,7 +887,7 @@ bool CipherBase::SetAutoPadding(bool auto_padding) {
 
 void CipherBase::SetAutoPadding(const FunctionCallbackInfo<Value>& args) {
   CipherBase* cipher;
-  ASSIGN_OR_RETURN_UNWRAP(&cipher, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&cipher, args.This());
 
   bool b = cipher->SetAutoPadding(args.Length() < 1 || args[0]->IsTrue());
   args.GetReturnValue().Set(b);  // Possibly report invalid state failure
@@ -962,7 +962,7 @@ void CipherBase::Final(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   CipherBase* cipher;
-  ASSIGN_OR_RETURN_UNWRAP(&cipher, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&cipher, args.This());
   if (cipher->ctx_ == nullptr)
     return THROW_ERR_CRYPTO_INVALID_STATE(env);
 

--- a/src/crypto/crypto_context.cc
+++ b/src/crypto/crypto_context.cc
@@ -422,7 +422,7 @@ void SecureContext::New(const FunctionCallbackInfo<Value>& args) {
 
 void SecureContext::Init(const FunctionCallbackInfo<Value>& args) {
   SecureContext* sc;
-  ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&sc, args.This());
   Environment* env = sc->env();
 
   CHECK_EQ(args.Length(), 3);
@@ -595,7 +595,7 @@ void SecureContext::SetKey(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   SecureContext* sc;
-  ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&sc, args.This());
 
   CHECK_GE(args.Length(), 1);  // Private key argument is mandatory
 
@@ -626,7 +626,7 @@ void SecureContext::SetKey(const FunctionCallbackInfo<Value>& args) {
 
 void SecureContext::SetSigalgs(const FunctionCallbackInfo<Value>& args) {
   SecureContext* sc;
-  ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&sc, args.This());
   Environment* env = sc->env();
   ClearErrorOnReturn clear_error_on_return;
 
@@ -644,7 +644,7 @@ void SecureContext::SetEngineKey(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   SecureContext* sc;
-  ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&sc, args.This());
 
   CHECK_EQ(args.Length(), 2);
 
@@ -707,7 +707,7 @@ void SecureContext::SetCert(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   SecureContext* sc;
-  ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&sc, args.This());
 
   CHECK_GE(args.Length(), 1);  // Certificate argument is mandatory
 
@@ -734,7 +734,7 @@ void SecureContext::AddCACert(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   SecureContext* sc;
-  ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&sc, args.This());
 
   CHECK_GE(args.Length(), 1);  // CA certificate argument is mandatory
 
@@ -771,7 +771,7 @@ void SecureContext::AddCRL(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   SecureContext* sc;
-  ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&sc, args.This());
 
   CHECK_GE(args.Length(), 1);  // CRL argument is mandatory
 
@@ -790,7 +790,7 @@ void SecureContext::SetRootCerts() {
 
 void SecureContext::AddRootCerts(const FunctionCallbackInfo<Value>& args) {
   SecureContext* sc;
-  ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&sc, args.This());
   sc->SetRootCerts();
 }
 
@@ -798,7 +798,7 @@ void SecureContext::SetCipherSuites(const FunctionCallbackInfo<Value>& args) {
   // BoringSSL doesn't allow API config of TLS1.3 cipher suites.
 #ifndef OPENSSL_IS_BORINGSSL
   SecureContext* sc;
-  ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&sc, args.This());
   Environment* env = sc->env();
   ClearErrorOnReturn clear_error_on_return;
 
@@ -813,7 +813,7 @@ void SecureContext::SetCipherSuites(const FunctionCallbackInfo<Value>& args) {
 
 void SecureContext::SetCiphers(const FunctionCallbackInfo<Value>& args) {
   SecureContext* sc;
-  ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&sc, args.This());
   Environment* env = sc->env();
   ClearErrorOnReturn clear_error_on_return;
 
@@ -837,7 +837,7 @@ void SecureContext::SetCiphers(const FunctionCallbackInfo<Value>& args) {
 
 void SecureContext::SetECDHCurve(const FunctionCallbackInfo<Value>& args) {
   SecureContext* sc;
-  ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&sc, args.This());
   Environment* env = sc->env();
 
   CHECK_GE(args.Length(), 1);  // ECDH curve name argument is mandatory
@@ -899,7 +899,7 @@ void SecureContext::SetDHParam(const FunctionCallbackInfo<Value>& args) {
 
 void SecureContext::SetMinProto(const FunctionCallbackInfo<Value>& args) {
   SecureContext* sc;
-  ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&sc, args.This());
 
   CHECK_EQ(args.Length(), 1);
   CHECK(args[0]->IsInt32());
@@ -911,7 +911,7 @@ void SecureContext::SetMinProto(const FunctionCallbackInfo<Value>& args) {
 
 void SecureContext::SetMaxProto(const FunctionCallbackInfo<Value>& args) {
   SecureContext* sc;
-  ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&sc, args.This());
 
   CHECK_EQ(args.Length(), 1);
   CHECK(args[0]->IsInt32());
@@ -923,7 +923,7 @@ void SecureContext::SetMaxProto(const FunctionCallbackInfo<Value>& args) {
 
 void SecureContext::GetMinProto(const FunctionCallbackInfo<Value>& args) {
   SecureContext* sc;
-  ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&sc, args.This());
 
   CHECK_EQ(args.Length(), 0);
 
@@ -934,7 +934,7 @@ void SecureContext::GetMinProto(const FunctionCallbackInfo<Value>& args) {
 
 void SecureContext::GetMaxProto(const FunctionCallbackInfo<Value>& args) {
   SecureContext* sc;
-  ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&sc, args.This());
 
   CHECK_EQ(args.Length(), 0);
 
@@ -946,7 +946,7 @@ void SecureContext::GetMaxProto(const FunctionCallbackInfo<Value>& args) {
 void SecureContext::SetOptions(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   SecureContext* sc;
-  ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&sc, args.This());
 
   CHECK_GE(args.Length(), 1);
   CHECK(args[0]->IsNumber());
@@ -960,7 +960,7 @@ void SecureContext::SetOptions(const FunctionCallbackInfo<Value>& args) {
 void SecureContext::SetSessionIdContext(
     const FunctionCallbackInfo<Value>& args) {
   SecureContext* sc;
-  ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&sc, args.This());
   Environment* env = sc->env();
 
   CHECK_GE(args.Length(), 1);
@@ -992,7 +992,7 @@ void SecureContext::SetSessionIdContext(
 
 void SecureContext::SetSessionTimeout(const FunctionCallbackInfo<Value>& args) {
   SecureContext* sc;
-  ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&sc, args.This());
 
   CHECK_GE(args.Length(), 1);
   CHECK(args[0]->IsInt32());
@@ -1003,7 +1003,7 @@ void SecureContext::SetSessionTimeout(const FunctionCallbackInfo<Value>& args) {
 
 void SecureContext::Close(const FunctionCallbackInfo<Value>& args) {
   SecureContext* sc;
-  ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&sc, args.This());
   sc->Reset();
 }
 
@@ -1015,7 +1015,7 @@ void SecureContext::LoadPKCS12(const FunctionCallbackInfo<Value>& args) {
   bool ret = false;
 
   SecureContext* sc;
-  ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&sc, args.This());
   ClearErrorOnReturn clear_error_on_return;
 
   if (args.Length() < 1) {
@@ -1124,7 +1124,7 @@ void SecureContext::SetClientCertEngine(
   CHECK(args[0]->IsString());
 
   SecureContext* sc;
-  ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&sc, args.This());
 
   MarkPopErrorOnReturn mark_pop_error_on_return;
 
@@ -1161,7 +1161,7 @@ void SecureContext::SetClientCertEngine(
 
 void SecureContext::GetTicketKeys(const FunctionCallbackInfo<Value>& args) {
   SecureContext* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
 
   Local<Object> buff;
   if (!Buffer::New(wrap->env(), 48).ToLocal(&buff))
@@ -1176,7 +1176,7 @@ void SecureContext::GetTicketKeys(const FunctionCallbackInfo<Value>& args) {
 
 void SecureContext::SetTicketKeys(const FunctionCallbackInfo<Value>& args) {
   SecureContext* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
 
   CHECK_GE(args.Length(), 1);  // Ticket keys argument is mandatory
   CHECK(args[0]->IsArrayBufferView());
@@ -1196,7 +1196,7 @@ void SecureContext::SetTicketKeys(const FunctionCallbackInfo<Value>& args) {
 void SecureContext::EnableTicketKeyCallback(
     const FunctionCallbackInfo<Value>& args) {
   SecureContext* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
 
   SSL_CTX_set_tlsext_ticket_key_cb(wrap->ctx_.get(), TicketKeyCallback);
 }
@@ -1350,7 +1350,7 @@ void SecureContext::CtxGetter(const FunctionCallbackInfo<Value>& info) {
 template <bool primary>
 void SecureContext::GetCertificate(const FunctionCallbackInfo<Value>& args) {
   SecureContext* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
   Environment* env = wrap->env();
   X509* cert;
 

--- a/src/crypto/crypto_dh.cc
+++ b/src/crypto/crypto_dh.cc
@@ -292,7 +292,7 @@ void DiffieHellman::GenerateKeys(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   DiffieHellman* diffieHellman;
-  ASSIGN_OR_RETURN_UNWRAP(&diffieHellman, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&diffieHellman, args.This());
 
   if (!DH_generate_key(diffieHellman->dh_.get())) {
     return ThrowCryptoError(env, ERR_get_error(), "Key generation failed");
@@ -327,7 +327,7 @@ void DiffieHellman::GetField(const FunctionCallbackInfo<Value>& args,
   Environment* env = Environment::GetCurrent(args);
 
   DiffieHellman* dh;
-  ASSIGN_OR_RETURN_UNWRAP(&dh, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&dh, args.This());
 
   const BIGNUM* num = get_field(dh->dh_.get());
   if (num == nullptr)
@@ -388,7 +388,7 @@ void DiffieHellman::ComputeSecret(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   DiffieHellman* diffieHellman;
-  ASSIGN_OR_RETURN_UNWRAP(&diffieHellman, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&diffieHellman, args.This());
 
   ClearErrorOnReturn clear_error_on_return;
 
@@ -447,7 +447,7 @@ void DiffieHellman::SetKey(const FunctionCallbackInfo<Value>& args,
                            int (*set_field)(DH*, BIGNUM*), const char* what) {
   Environment* env = Environment::GetCurrent(args);
   DiffieHellman* dh;
-  ASSIGN_OR_RETURN_UNWRAP(&dh, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&dh, args.This());
   CHECK_EQ(args.Length(), 1);
   ArrayBufferOrViewContents<unsigned char> buf(args[0]);
   if (UNLIKELY(!buf.CheckSizeInt32()))
@@ -473,7 +473,7 @@ void DiffieHellman::VerifyErrorGetter(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
   DiffieHellman* diffieHellman;
-  ASSIGN_OR_RETURN_UNWRAP(&diffieHellman, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&diffieHellman, args.This());
 
   args.GetReturnValue().Set(diffieHellman->verifyError_);
 }

--- a/src/crypto/crypto_ec.cc
+++ b/src/crypto/crypto_ec.cc
@@ -155,7 +155,7 @@ void ECDH::GenerateKeys(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   ECDH* ecdh;
-  ASSIGN_OR_RETURN_UNWRAP(&ecdh, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&ecdh, args.This());
 
   if (!EC_KEY_generate_key(ecdh->key_.get()))
     return THROW_ERR_CRYPTO_OPERATION_FAILED(env, "Failed to generate key");
@@ -196,7 +196,7 @@ void ECDH::ComputeSecret(const FunctionCallbackInfo<Value>& args) {
   CHECK(IsAnyBufferSource(args[0]));
 
   ECDH* ecdh;
-  ASSIGN_OR_RETURN_UNWRAP(&ecdh, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&ecdh, args.This());
 
   MarkPopErrorOnReturn mark_pop_error_on_return;
 
@@ -240,7 +240,7 @@ void ECDH::GetPublicKey(const FunctionCallbackInfo<Value>& args) {
   CHECK_EQ(args.Length(), 1);
 
   ECDH* ecdh;
-  ASSIGN_OR_RETURN_UNWRAP(&ecdh, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&ecdh, args.This());
 
   const EC_GROUP* group = EC_KEY_get0_group(ecdh->key_.get());
   const EC_POINT* pub = EC_KEY_get0_public_key(ecdh->key_.get());
@@ -263,7 +263,7 @@ void ECDH::GetPrivateKey(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   ECDH* ecdh;
-  ASSIGN_OR_RETURN_UNWRAP(&ecdh, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&ecdh, args.This());
 
   const BIGNUM* b = EC_KEY_get0_private_key(ecdh->key_.get());
   if (b == nullptr)
@@ -289,7 +289,7 @@ void ECDH::SetPrivateKey(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   ECDH* ecdh;
-  ASSIGN_OR_RETURN_UNWRAP(&ecdh, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&ecdh, args.This());
 
   ArrayBufferOrViewContents<unsigned char> priv_buffer(args[0]);
   if (UNLIKELY(!priv_buffer.CheckSizeInt32()))
@@ -345,7 +345,7 @@ void ECDH::SetPublicKey(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   ECDH* ecdh;
-  ASSIGN_OR_RETURN_UNWRAP(&ecdh, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&ecdh, args.This());
 
   CHECK(IsAnyBufferSource(args[0]));
 

--- a/src/crypto/crypto_hash.cc
+++ b/src/crypto/crypto_hash.cc
@@ -378,7 +378,7 @@ void Hash::HashDigest(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   Hash* hash;
-  ASSIGN_OR_RETURN_UNWRAP(&hash, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&hash, args.This());
 
   enum encoding encoding = BUFFER;
   if (args.Length() >= 1) {

--- a/src/crypto/crypto_hmac.cc
+++ b/src/crypto/crypto_hmac.cc
@@ -85,7 +85,7 @@ void Hmac::HmacInit(const char* hash_type, const char* key, int key_len) {
 
 void Hmac::HmacInit(const FunctionCallbackInfo<Value>& args) {
   Hmac* hmac;
-  ASSIGN_OR_RETURN_UNWRAP(&hmac, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&hmac, args.This());
   Environment* env = hmac->env();
 
   const node::Utf8Value hash_type(env->isolate(), args[0]);
@@ -114,7 +114,7 @@ void Hmac::HmacDigest(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   Hmac* hmac;
-  ASSIGN_OR_RETURN_UNWRAP(&hmac, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&hmac, args.This());
 
   enum encoding encoding = BUFFER;
   if (args.Length() >= 1) {

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -971,7 +971,7 @@ KeyObjectHandle::KeyObjectHandle(Environment* env,
 
 void KeyObjectHandle::Init(const FunctionCallbackInfo<Value>& args) {
   KeyObjectHandle* key;
-  ASSIGN_OR_RETURN_UNWRAP(&key, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&key, args.This());
   MarkPopErrorOnReturn mark_pop_error_on_return;
 
   CHECK(args[0]->IsInt32());
@@ -1015,7 +1015,7 @@ void KeyObjectHandle::Init(const FunctionCallbackInfo<Value>& args) {
 void KeyObjectHandle::InitJWK(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   KeyObjectHandle* key;
-  ASSIGN_OR_RETURN_UNWRAP(&key, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&key, args.This());
   MarkPopErrorOnReturn mark_pop_error_on_return;
 
   // The argument must be a JavaScript object that we will inspect
@@ -1054,7 +1054,7 @@ void KeyObjectHandle::InitJWK(const FunctionCallbackInfo<Value>& args) {
 void KeyObjectHandle::InitECRaw(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   KeyObjectHandle* key;
-  ASSIGN_OR_RETURN_UNWRAP(&key, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&key, args.This());
 
   CHECK(args[0]->IsString());
   Utf8Value name(env->isolate(), args[0]);
@@ -1092,7 +1092,7 @@ void KeyObjectHandle::InitECRaw(const FunctionCallbackInfo<Value>& args) {
 void KeyObjectHandle::InitEDRaw(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   KeyObjectHandle* key;
-  ASSIGN_OR_RETURN_UNWRAP(&key, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&key, args.This());
 
   CHECK(args[0]->IsString());
   Utf8Value name(env->isolate(), args[0]);
@@ -1134,7 +1134,7 @@ void KeyObjectHandle::InitEDRaw(const FunctionCallbackInfo<Value>& args) {
 void KeyObjectHandle::Equals(const FunctionCallbackInfo<Value>& args) {
   KeyObjectHandle* self_handle;
   KeyObjectHandle* arg_handle;
-  ASSIGN_OR_RETURN_UNWRAP(&self_handle, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&self_handle, args.This());
   ASSIGN_OR_RETURN_UNWRAP(&arg_handle, args[0].As<Object>());
   std::shared_ptr<KeyObjectData> key = self_handle->Data();
   std::shared_ptr<KeyObjectData> key2 = arg_handle->Data();
@@ -1182,7 +1182,7 @@ void KeyObjectHandle::Equals(const FunctionCallbackInfo<Value>& args) {
 void KeyObjectHandle::GetKeyDetail(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   KeyObjectHandle* key;
-  ASSIGN_OR_RETURN_UNWRAP(&key, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&key, args.This());
 
   CHECK(args[0]->IsObject());
 
@@ -1235,7 +1235,7 @@ Local<Value> KeyObjectHandle::GetAsymmetricKeyType() const {
 void KeyObjectHandle::GetAsymmetricKeyType(
     const FunctionCallbackInfo<Value>& args) {
   KeyObjectHandle* key;
-  ASSIGN_OR_RETURN_UNWRAP(&key, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&key, args.This());
 
   args.GetReturnValue().Set(key->GetAsymmetricKeyType());
 }
@@ -1263,7 +1263,7 @@ bool KeyObjectHandle::CheckEcKeyData() const {
 
 void KeyObjectHandle::CheckEcKeyData(const FunctionCallbackInfo<Value>& args) {
   KeyObjectHandle* key;
-  ASSIGN_OR_RETURN_UNWRAP(&key, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&key, args.This());
 
   args.GetReturnValue().Set(key->CheckEcKeyData());
 }
@@ -1271,14 +1271,14 @@ void KeyObjectHandle::CheckEcKeyData(const FunctionCallbackInfo<Value>& args) {
 void KeyObjectHandle::GetSymmetricKeySize(
     const FunctionCallbackInfo<Value>& args) {
   KeyObjectHandle* key;
-  ASSIGN_OR_RETURN_UNWRAP(&key, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&key, args.This());
   args.GetReturnValue().Set(
       static_cast<uint32_t>(key->Data()->GetSymmetricKeySize()));
 }
 
 void KeyObjectHandle::Export(const FunctionCallbackInfo<Value>& args) {
   KeyObjectHandle* key;
-  ASSIGN_OR_RETURN_UNWRAP(&key, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&key, args.This());
 
   KeyType type = key->Data()->GetKeyType();
 
@@ -1328,7 +1328,7 @@ void KeyObjectHandle::ExportJWK(
     const v8::FunctionCallbackInfo<v8::Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   KeyObjectHandle* key;
-  ASSIGN_OR_RETURN_UNWRAP(&key, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&key, args.This());
 
   CHECK(args[0]->IsObject());
   CHECK(args[1]->IsBoolean());

--- a/src/crypto/crypto_sig.cc
+++ b/src/crypto/crypto_sig.cc
@@ -371,7 +371,7 @@ void Sign::New(const FunctionCallbackInfo<Value>& args) {
 void Sign::SignInit(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Sign* sign;
-  ASSIGN_OR_RETURN_UNWRAP(&sign, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&sign, args.This());
 
   const node::Utf8Value sign_type(args.GetIsolate(), args[0]);
   crypto::CheckThrow(env, sign->Init(*sign_type));
@@ -414,7 +414,7 @@ Sign::SignResult Sign::SignFinal(
 void Sign::SignFinal(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Sign* sign;
-  ASSIGN_OR_RETURN_UNWRAP(&sign, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&sign, args.This());
 
   ClearErrorOnReturn clear_error_on_return;
 
@@ -492,7 +492,7 @@ void Verify::New(const FunctionCallbackInfo<Value>& args) {
 void Verify::VerifyInit(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Verify* verify;
-  ASSIGN_OR_RETURN_UNWRAP(&verify, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&verify, args.This());
 
   const node::Utf8Value verify_type(args.GetIsolate(), args[0]);
   crypto::CheckThrow(env, verify->Init(*verify_type));
@@ -545,7 +545,7 @@ void Verify::VerifyFinal(const FunctionCallbackInfo<Value>& args) {
   ClearErrorOnReturn clear_error_on_return;
 
   Verify* verify;
-  ASSIGN_OR_RETURN_UNWRAP(&verify, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&verify, args.This());
 
   unsigned int offset = 0;
   ManagedEVPPKey pkey =

--- a/src/crypto/crypto_tls.cc
+++ b/src/crypto/crypto_tls.cc
@@ -506,7 +506,7 @@ void TLSWrap::Wrap(const FunctionCallbackInfo<Value>& args) {
 
 void TLSWrap::Receive(const FunctionCallbackInfo<Value>& args) {
   TLSWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
 
   ArrayBufferViewContents<char> buffer(args[0]);
   const char* data = buffer.data();
@@ -528,7 +528,7 @@ void TLSWrap::Receive(const FunctionCallbackInfo<Value>& args) {
 
 void TLSWrap::Start(const FunctionCallbackInfo<Value>& args) {
   TLSWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
 
   CHECK(!wrap->started_);
   wrap->started_ = true;
@@ -1155,7 +1155,7 @@ int TLSWrap::DoShutdown(ShutdownWrap* req_wrap) {
 
 void TLSWrap::SetVerifyMode(const FunctionCallbackInfo<Value>& args) {
   TLSWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
 
   CHECK_EQ(args.Length(), 2);
   CHECK(args[0]->IsBoolean());
@@ -1187,7 +1187,7 @@ void TLSWrap::SetVerifyMode(const FunctionCallbackInfo<Value>& args) {
 
 void TLSWrap::EnableSessionCallbacks(const FunctionCallbackInfo<Value>& args) {
   TLSWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
   CHECK_NOT_NULL(wrap->ssl_);
   wrap->enable_session_callbacks();
 
@@ -1203,7 +1203,7 @@ void TLSWrap::EnableSessionCallbacks(const FunctionCallbackInfo<Value>& args) {
 
 void TLSWrap::EnableKeylogCallback(const FunctionCallbackInfo<Value>& args) {
   TLSWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
   CHECK(wrap->sc_);
   wrap->sc_->SetKeylogCallback(KeylogCallback);
 }
@@ -1220,7 +1220,7 @@ void TLSWrap::EnableKeylogCallback(const FunctionCallbackInfo<Value>& args) {
 
 void TLSWrap::EnableTrace(const FunctionCallbackInfo<Value>& args) {
   TLSWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
 
 #if HAVE_SSL_TRACE
   if (wrap->ssl_) {
@@ -1243,7 +1243,7 @@ void TLSWrap::EnableTrace(const FunctionCallbackInfo<Value>& args) {
 
 void TLSWrap::DestroySSL(const FunctionCallbackInfo<Value>& args) {
   TLSWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
   wrap->Destroy();
   Debug(wrap, "DestroySSL() finished");
 }
@@ -1272,7 +1272,7 @@ void TLSWrap::Destroy() {
 
 void TLSWrap::EnableCertCb(const FunctionCallbackInfo<Value>& args) {
   TLSWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
   wrap->WaitForCertCb(OnClientHelloParseEnd, wrap);
 }
 
@@ -1289,7 +1289,7 @@ void TLSWrap::OnClientHelloParseEnd(void* arg) {
 
 void TLSWrap::EnableALPNCb(const FunctionCallbackInfo<Value>& args) {
   TLSWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
   wrap->alpn_callback_enabled_ = true;
 
   SSL* ssl = wrap->ssl_.get();
@@ -1301,7 +1301,7 @@ void TLSWrap::GetServername(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   TLSWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
 
   CHECK_NOT_NULL(wrap->ssl_);
 
@@ -1317,7 +1317,7 @@ void TLSWrap::SetServername(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   TLSWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
 
   CHECK_EQ(args.Length(), 1);
   CHECK(args[0]->IsString());
@@ -1382,7 +1382,7 @@ int TLSWrap::SetCACerts(SecureContext* sc) {
 
 void TLSWrap::SetPskIdentityHint(const FunctionCallbackInfo<Value>& args) {
   TLSWrap* p;
-  ASSIGN_OR_RETURN_UNWRAP(&p, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&p, args.This());
   CHECK_NOT_NULL(p->ssl_);
 
   Environment* env = p->env();
@@ -1399,7 +1399,7 @@ void TLSWrap::SetPskIdentityHint(const FunctionCallbackInfo<Value>& args) {
 
 void TLSWrap::EnablePskCallback(const FunctionCallbackInfo<Value>& args) {
   TLSWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
   CHECK_NOT_NULL(wrap->ssl_);
 
   SSL_set_psk_server_callback(wrap->ssl_.get(), PskServerCallback);
@@ -1533,7 +1533,7 @@ void TLSWrap::MemoryInfo(MemoryTracker* tracker) const {
 void TLSWrap::CertCbDone(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   TLSWrap* w;
-  ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
 
   CHECK(w->is_waiting_cert_cb() && w->cert_cb_running_);
 
@@ -1578,7 +1578,7 @@ void TLSWrap::CertCbDone(const FunctionCallbackInfo<Value>& args) {
 
 void TLSWrap::SetALPNProtocols(const FunctionCallbackInfo<Value>& args) {
   TLSWrap* w;
-  ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
   Environment* env = w->env();
   if (args.Length() < 1 || !Buffer::HasInstance(args[0]))
     return env->ThrowTypeError("Must give a Buffer as first argument");
@@ -1597,7 +1597,7 @@ void TLSWrap::SetALPNProtocols(const FunctionCallbackInfo<Value>& args) {
 
 void TLSWrap::GetPeerCertificate(const FunctionCallbackInfo<Value>& args) {
   TLSWrap* w;
-  ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
   Environment* env = w->env();
 
   bool abbreviated = args.Length() < 1 || !args[0]->IsTrue();
@@ -1613,7 +1613,7 @@ void TLSWrap::GetPeerCertificate(const FunctionCallbackInfo<Value>& args) {
 
 void TLSWrap::GetPeerX509Certificate(const FunctionCallbackInfo<Value>& args) {
   TLSWrap* w;
-  ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
   Environment* env = w->env();
 
   X509Certificate::GetPeerCertificateFlag flag = w->is_server()
@@ -1627,7 +1627,7 @@ void TLSWrap::GetPeerX509Certificate(const FunctionCallbackInfo<Value>& args) {
 
 void TLSWrap::GetCertificate(const FunctionCallbackInfo<Value>& args) {
   TLSWrap* w;
-  ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
   Environment* env = w->env();
 
   Local<Value> ret;
@@ -1637,7 +1637,7 @@ void TLSWrap::GetCertificate(const FunctionCallbackInfo<Value>& args) {
 
 void TLSWrap::GetX509Certificate(const FunctionCallbackInfo<Value>& args) {
   TLSWrap* w;
-  ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
   Environment* env = w->env();
   Local<Value> ret;
   if (X509Certificate::GetCert(env, w->ssl_).ToLocal(&ret))
@@ -1648,7 +1648,7 @@ void TLSWrap::GetFinished(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   TLSWrap* w;
-  ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
 
   // We cannot just pass nullptr to SSL_get_finished()
   // because it would further be propagated to memcpy(),
@@ -1679,7 +1679,7 @@ void TLSWrap::GetPeerFinished(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   TLSWrap* w;
-  ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
 
   // We cannot just pass nullptr to SSL_get_peer_finished()
   // because it would further be propagated to memcpy(),
@@ -1710,7 +1710,7 @@ void TLSWrap::GetSession(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   TLSWrap* w;
-  ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
 
   SSL_SESSION* sess = SSL_get_session(w->ssl_.get());
   if (sess == nullptr)
@@ -1739,7 +1739,7 @@ void TLSWrap::SetSession(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   TLSWrap* w;
-  ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
 
   if (args.Length() < 1)
     return THROW_ERR_MISSING_ARGS(env, "Session argument is mandatory");
@@ -1756,7 +1756,7 @@ void TLSWrap::SetSession(const FunctionCallbackInfo<Value>& args) {
 
 void TLSWrap::IsSessionReused(const FunctionCallbackInfo<Value>& args) {
   TLSWrap* w;
-  ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
   bool yes = SSL_session_reused(w->ssl_.get());
   args.GetReturnValue().Set(yes);
 }
@@ -1764,7 +1764,7 @@ void TLSWrap::IsSessionReused(const FunctionCallbackInfo<Value>& args) {
 void TLSWrap::VerifyError(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   TLSWrap* w;
-  ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
 
   // XXX(bnoordhuis) The UNABLE_TO_GET_ISSUER_CERT error when there is no
   // peer certificate is questionable but it's compatible with what was
@@ -1792,14 +1792,14 @@ void TLSWrap::VerifyError(const FunctionCallbackInfo<Value>& args) {
 void TLSWrap::GetCipher(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   TLSWrap* w;
-  ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
   args.GetReturnValue().Set(
       GetCipherInfo(env, w->ssl_).FromMaybe(Local<Object>()));
 }
 
 void TLSWrap::LoadSession(const FunctionCallbackInfo<Value>& args) {
   TLSWrap* w;
-  ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
 
   // TODO(@sam-github) check arg length and types in js, and CHECK in c++
   if (args.Length() >= 1 && Buffer::HasInstance(args[0])) {
@@ -1816,7 +1816,7 @@ void TLSWrap::LoadSession(const FunctionCallbackInfo<Value>& args) {
 void TLSWrap::GetSharedSigalgs(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   TLSWrap* w;
-  ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
 
   SSL* ssl = w->ssl_.get();
   int nsig = SSL_get_shared_sigalgs(ssl, 0, nullptr, nullptr, nullptr, nullptr,
@@ -1898,7 +1898,7 @@ void TLSWrap::ExportKeyingMaterial(const FunctionCallbackInfo<Value>& args) {
 
   Environment* env = Environment::GetCurrent(args);
   TLSWrap* w;
-  ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
 
   uint32_t olen = args[0].As<Uint32>()->Value();
   Utf8Value label(env->isolate(), args[1]);
@@ -1937,13 +1937,13 @@ void TLSWrap::ExportKeyingMaterial(const FunctionCallbackInfo<Value>& args) {
 
 void TLSWrap::EndParser(const FunctionCallbackInfo<Value>& args) {
   TLSWrap* w;
-  ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
   w->hello_parser_.End();
 }
 
 void TLSWrap::Renegotiate(const FunctionCallbackInfo<Value>& args) {
   TLSWrap* w;
-  ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
   ClearErrorOnReturn clear_error_on_return;
   if (SSL_renegotiate(w->ssl_.get()) != 1)
     return ThrowCryptoError(w->env(), ERR_get_error());
@@ -1951,7 +1951,7 @@ void TLSWrap::Renegotiate(const FunctionCallbackInfo<Value>& args) {
 
 void TLSWrap::GetTLSTicket(const FunctionCallbackInfo<Value>& args) {
   TLSWrap* w;
-  ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
   Environment* env = w->env();
 
   SSL_SESSION* sess = SSL_get_session(w->ssl_.get());
@@ -1971,14 +1971,14 @@ void TLSWrap::GetTLSTicket(const FunctionCallbackInfo<Value>& args) {
 
 void TLSWrap::NewSessionDone(const FunctionCallbackInfo<Value>& args) {
   TLSWrap* w;
-  ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
   w->awaiting_new_session_ = false;
   w->NewSessionDoneCb();
 }
 
 void TLSWrap::SetOCSPResponse(const FunctionCallbackInfo<Value>& args) {
   TLSWrap* w;
-  ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
   Environment* env = w->env();
 
   if (args.Length() < 1)
@@ -1991,14 +1991,14 @@ void TLSWrap::SetOCSPResponse(const FunctionCallbackInfo<Value>& args) {
 
 void TLSWrap::RequestOCSP(const FunctionCallbackInfo<Value>& args) {
   TLSWrap* w;
-  ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
 
   SSL_set_tlsext_status_type(w->ssl_.get(), TLSEXT_STATUSTYPE_ocsp);
 }
 
 void TLSWrap::GetEphemeralKeyInfo(const FunctionCallbackInfo<Value>& args) {
   TLSWrap* w;
-  ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
   Environment* env = Environment::GetCurrent(args);
 
   CHECK(w->ssl_);
@@ -2017,7 +2017,7 @@ void TLSWrap::GetEphemeralKeyInfo(const FunctionCallbackInfo<Value>& args) {
 void TLSWrap::GetProtocol(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   TLSWrap* w;
-  ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
   args.GetReturnValue().Set(
       OneByteString(env->isolate(), SSL_get_version(w->ssl_.get())));
 }
@@ -2025,7 +2025,7 @@ void TLSWrap::GetProtocol(const FunctionCallbackInfo<Value>& args) {
 void TLSWrap::GetALPNNegotiatedProto(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   TLSWrap* w;
-  ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
 
   const unsigned char* alpn_proto;
   unsigned int alpn_proto_len;
@@ -2051,7 +2051,7 @@ void TLSWrap::GetALPNNegotiatedProto(const FunctionCallbackInfo<Value>& args) {
 void TLSWrap::WritesIssuedByPrevListenerDone(
     const FunctionCallbackInfo<Value>& args) {
   TLSWrap* w;
-  ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
 
   Debug(w, "WritesIssuedByPrevListenerDone is called");
   w->has_active_write_issued_by_prev_listener_ = false;
@@ -2076,7 +2076,7 @@ void TLSWrap::SetMaxSendFragment(const FunctionCallbackInfo<Value>& args) {
   CHECK(args.Length() >= 1 && args[0]->IsNumber());
   Environment* env = Environment::GetCurrent(args);
   TLSWrap* w;
-  ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
   int rv = SSL_set_max_send_fragment(
       w->ssl_.get(),
       args[0]->Int32Value(env->context()).FromJust());

--- a/src/crypto/crypto_util.h
+++ b/src/crypto/crypto_util.h
@@ -136,7 +136,7 @@ void Decode(const v8::FunctionCallbackInfo<v8::Value>& args,
             void (*callback)(T*, const v8::FunctionCallbackInfo<v8::Value>&,
                              const char*, size_t)) {
   T* ctx;
-  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.This());
 
   if (args[0]->IsString()) {
     StringBytes::InlineDecoder decoder;
@@ -412,7 +412,7 @@ class CryptoJob : public AsyncWrap, public ThreadPoolWork {
     Environment* env = Environment::GetCurrent(args);
 
     CryptoJob<CryptoJobTraits>* job;
-    ASSIGN_OR_RETURN_UNWRAP(&job, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&job, args.This());
     if (job->mode() == kCryptoJobAsync)
       return job->ScheduleWork();
 

--- a/src/crypto/crypto_x509.cc
+++ b/src/crypto/crypto_x509.cc
@@ -56,7 +56,7 @@ template <const EVP_MD* (*algo)()>
 void Fingerprint(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   X509Certificate* cert;
-  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.This());
   Local<Value> ret;
   if (GetFingerprintDigest(env, algo(), cert->get()).ToLocal(&ret))
     args.GetReturnValue().Set(ret);
@@ -208,7 +208,7 @@ template <MaybeLocal<Value> Property(
 static void ReturnPropertyThroughBIO(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   X509Certificate* cert;
-  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.This());
   BIOPointer bio(BIO_new(BIO_s_mem()));
   CHECK(bio);
   Local<Value> ret;
@@ -244,7 +244,7 @@ template <MaybeLocal<Value> Property(Environment* env, X509* cert)>
 static void ReturnProperty(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   X509Certificate* cert;
-  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.This());
   Local<Value> ret;
   if (Property(env, cert->get()).ToLocal(&ret)) args.GetReturnValue().Set(ret);
 }
@@ -264,7 +264,7 @@ void X509Certificate::Raw(const FunctionCallbackInfo<Value>& args) {
 void X509Certificate::PublicKey(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   X509Certificate* cert;
-  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.This());
 
   // TODO(tniessen): consider checking X509_get_pubkey() when the
   // X509Certificate object is being created.
@@ -283,7 +283,7 @@ void X509Certificate::PublicKey(const FunctionCallbackInfo<Value>& args) {
 void X509Certificate::Pem(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   X509Certificate* cert;
-  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.This());
   BIOPointer bio(BIO_new(BIO_s_mem()));
   CHECK(bio);
   if (PEM_write_bio_X509(bio.get(), cert->get()))
@@ -293,14 +293,14 @@ void X509Certificate::Pem(const FunctionCallbackInfo<Value>& args) {
 void X509Certificate::CheckCA(const FunctionCallbackInfo<Value>& args) {
   X509Certificate* cert;
   ClearErrorOnReturn clear_error_on_return;
-  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.This());
   args.GetReturnValue().Set(X509_check_ca(cert->get()) == 1);
 }
 
 void X509Certificate::CheckHost(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   X509Certificate* cert;
-  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.This());
 
   CHECK(args[0]->IsString());  // name
   CHECK(args[1]->IsUint32());  // flags
@@ -335,7 +335,7 @@ void X509Certificate::CheckHost(const FunctionCallbackInfo<Value>& args) {
 void X509Certificate::CheckEmail(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   X509Certificate* cert;
-  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.This());
 
   CHECK(args[0]->IsString());  // name
   CHECK(args[1]->IsUint32());  // flags
@@ -362,7 +362,7 @@ void X509Certificate::CheckEmail(const FunctionCallbackInfo<Value>& args) {
 void X509Certificate::CheckIP(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   X509Certificate* cert;
-  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.This());
 
   CHECK(args[0]->IsString());  // IP
   CHECK(args[1]->IsUint32());  // flags
@@ -385,7 +385,7 @@ void X509Certificate::CheckIP(const FunctionCallbackInfo<Value>& args) {
 void X509Certificate::CheckIssued(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   X509Certificate* cert;
-  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.This());
 
   CHECK(args[0]->IsObject());
   CHECK(X509Certificate::HasInstance(env, args[0].As<Object>()));
@@ -401,7 +401,7 @@ void X509Certificate::CheckIssued(const FunctionCallbackInfo<Value>& args) {
 
 void X509Certificate::CheckPrivateKey(const FunctionCallbackInfo<Value>& args) {
   X509Certificate* cert;
-  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.This());
 
   CHECK(args[0]->IsObject());
   KeyObjectHandle* key;
@@ -418,7 +418,7 @@ void X509Certificate::CheckPrivateKey(const FunctionCallbackInfo<Value>& args) {
 
 void X509Certificate::Verify(const FunctionCallbackInfo<Value>& args) {
   X509Certificate* cert;
-  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.This());
 
   CHECK(args[0]->IsObject());
   KeyObjectHandle* key;
@@ -436,7 +436,7 @@ void X509Certificate::Verify(const FunctionCallbackInfo<Value>& args) {
 void X509Certificate::ToLegacy(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   X509Certificate* cert;
-  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.This());
   ClearErrorOnReturn clear_error_on_return;
   Local<Value> ret;
   if (X509ToObject(env, cert->get()).ToLocal(&ret))
@@ -445,7 +445,7 @@ void X509Certificate::ToLegacy(const FunctionCallbackInfo<Value>& args) {
 
 void X509Certificate::GetIssuerCert(const FunctionCallbackInfo<Value>& args) {
   X509Certificate* cert;
-  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.This());
   if (cert->issuer_cert_)
     args.GetReturnValue().Set(cert->issuer_cert_->object());
 }

--- a/src/handle_wrap.cc
+++ b/src/handle_wrap.cc
@@ -39,7 +39,7 @@ using v8::Value;
 
 void HandleWrap::Ref(const FunctionCallbackInfo<Value>& args) {
   HandleWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
 
   if (IsAlive(wrap))
     uv_ref(wrap->GetHandle());
@@ -48,7 +48,7 @@ void HandleWrap::Ref(const FunctionCallbackInfo<Value>& args) {
 
 void HandleWrap::Unref(const FunctionCallbackInfo<Value>& args) {
   HandleWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
 
   if (IsAlive(wrap))
     uv_unref(wrap->GetHandle());
@@ -57,14 +57,14 @@ void HandleWrap::Unref(const FunctionCallbackInfo<Value>& args) {
 
 void HandleWrap::HasRef(const FunctionCallbackInfo<Value>& args) {
   HandleWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
   args.GetReturnValue().Set(HasRef(wrap));
 }
 
 
 void HandleWrap::Close(const FunctionCallbackInfo<Value>& args) {
   HandleWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
 
   wrap->Close(args[0]);
 }

--- a/src/histogram.cc
+++ b/src/histogram.cc
@@ -165,7 +165,7 @@ void HistogramBase::MemoryInfo(MemoryTracker* tracker) const {
 
 void HistogramBase::RecordDelta(const FunctionCallbackInfo<Value>& args) {
   HistogramBase* histogram;
-  ASSIGN_OR_RETURN_UNWRAP(&histogram, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&histogram, args.This());
   (*histogram)->RecordDelta();
 }
 
@@ -185,7 +185,7 @@ void HistogramBase::Record(const FunctionCallbackInfo<Value>& args) {
   if (!lossless || value < 1)
     return THROW_ERR_OUT_OF_RANGE(env, "value is out of range");
   HistogramBase* histogram;
-  ASSIGN_OR_RETURN_UNWRAP(&histogram, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&histogram, args.This());
   (*histogram)->Record(value);
 }
 
@@ -204,7 +204,7 @@ void HistogramBase::FastRecord(Local<Value> receiver,
 void HistogramBase::Add(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   HistogramBase* histogram;
-  ASSIGN_OR_RETURN_UNWRAP(&histogram, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&histogram, args.This());
 
   CHECK(GetConstructorTemplate(env->isolate_data())->HasInstance(args[0]));
   HistogramBase* other;
@@ -432,7 +432,7 @@ void IntervalHistogram::OnStop() {
 
 void IntervalHistogram::Start(const FunctionCallbackInfo<Value>& args) {
   IntervalHistogram* histogram;
-  ASSIGN_OR_RETURN_UNWRAP(&histogram, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&histogram, args.This());
   histogram->OnStart(args[0]->IsTrue() ? StartFlags::RESET : StartFlags::NONE);
 }
 
@@ -444,7 +444,7 @@ void IntervalHistogram::FastStart(Local<Value> receiver, bool reset) {
 
 void IntervalHistogram::Stop(const FunctionCallbackInfo<Value>& args) {
   IntervalHistogram* histogram;
-  ASSIGN_OR_RETURN_UNWRAP(&histogram, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&histogram, args.This());
   histogram->OnStop();
 }
 
@@ -455,67 +455,67 @@ void IntervalHistogram::FastStop(Local<Value> receiver) {
 }
 
 void HistogramImpl::GetCount(const FunctionCallbackInfo<Value>& args) {
-  HistogramImpl* histogram = HistogramImpl::FromJSObject(args.Holder());
+  HistogramImpl* histogram = HistogramImpl::FromJSObject(args.This());
   double value = static_cast<double>((*histogram)->Count());
   args.GetReturnValue().Set(value);
 }
 
 void HistogramImpl::GetCountBigInt(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-  HistogramImpl* histogram = HistogramImpl::FromJSObject(args.Holder());
+  HistogramImpl* histogram = HistogramImpl::FromJSObject(args.This());
   args.GetReturnValue().Set(
       BigInt::NewFromUnsigned(env->isolate(), (*histogram)->Count()));
 }
 
 void HistogramImpl::GetMin(const FunctionCallbackInfo<Value>& args) {
-  HistogramImpl* histogram = HistogramImpl::FromJSObject(args.Holder());
+  HistogramImpl* histogram = HistogramImpl::FromJSObject(args.This());
   double value = static_cast<double>((*histogram)->Min());
   args.GetReturnValue().Set(value);
 }
 
 void HistogramImpl::GetMinBigInt(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-  HistogramImpl* histogram = HistogramImpl::FromJSObject(args.Holder());
+  HistogramImpl* histogram = HistogramImpl::FromJSObject(args.This());
   args.GetReturnValue().Set(BigInt::New(env->isolate(), (*histogram)->Min()));
 }
 
 void HistogramImpl::GetMax(const FunctionCallbackInfo<Value>& args) {
-  HistogramImpl* histogram = HistogramImpl::FromJSObject(args.Holder());
+  HistogramImpl* histogram = HistogramImpl::FromJSObject(args.This());
   double value = static_cast<double>((*histogram)->Max());
   args.GetReturnValue().Set(value);
 }
 
 void HistogramImpl::GetMaxBigInt(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-  HistogramImpl* histogram = HistogramImpl::FromJSObject(args.Holder());
+  HistogramImpl* histogram = HistogramImpl::FromJSObject(args.This());
   args.GetReturnValue().Set(BigInt::New(env->isolate(), (*histogram)->Max()));
 }
 
 void HistogramImpl::GetMean(const FunctionCallbackInfo<Value>& args) {
-  HistogramImpl* histogram = HistogramImpl::FromJSObject(args.Holder());
+  HistogramImpl* histogram = HistogramImpl::FromJSObject(args.This());
   args.GetReturnValue().Set((*histogram)->Mean());
 }
 
 void HistogramImpl::GetExceeds(const FunctionCallbackInfo<Value>& args) {
-  HistogramImpl* histogram = HistogramImpl::FromJSObject(args.Holder());
+  HistogramImpl* histogram = HistogramImpl::FromJSObject(args.This());
   double value = static_cast<double>((*histogram)->Exceeds());
   args.GetReturnValue().Set(value);
 }
 
 void HistogramImpl::GetExceedsBigInt(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-  HistogramImpl* histogram = HistogramImpl::FromJSObject(args.Holder());
+  HistogramImpl* histogram = HistogramImpl::FromJSObject(args.This());
   args.GetReturnValue().Set(
       BigInt::New(env->isolate(), (*histogram)->Exceeds()));
 }
 
 void HistogramImpl::GetStddev(const FunctionCallbackInfo<Value>& args) {
-  HistogramImpl* histogram = HistogramImpl::FromJSObject(args.Holder());
+  HistogramImpl* histogram = HistogramImpl::FromJSObject(args.This());
   args.GetReturnValue().Set((*histogram)->Stddev());
 }
 
 void HistogramImpl::GetPercentile(const FunctionCallbackInfo<Value>& args) {
-  HistogramImpl* histogram = HistogramImpl::FromJSObject(args.Holder());
+  HistogramImpl* histogram = HistogramImpl::FromJSObject(args.This());
   CHECK(args[0]->IsNumber());
   double percentile = args[0].As<Number>()->Value();
   double value = static_cast<double>((*histogram)->Percentile(percentile));
@@ -525,7 +525,7 @@ void HistogramImpl::GetPercentile(const FunctionCallbackInfo<Value>& args) {
 void HistogramImpl::GetPercentileBigInt(
     const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-  HistogramImpl* histogram = HistogramImpl::FromJSObject(args.Holder());
+  HistogramImpl* histogram = HistogramImpl::FromJSObject(args.This());
   CHECK(args[0]->IsNumber());
   double percentile = args[0].As<Number>()->Value();
   int64_t value = (*histogram)->Percentile(percentile);
@@ -534,7 +534,7 @@ void HistogramImpl::GetPercentileBigInt(
 
 void HistogramImpl::GetPercentiles(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-  HistogramImpl* histogram = HistogramImpl::FromJSObject(args.Holder());
+  HistogramImpl* histogram = HistogramImpl::FromJSObject(args.This());
   CHECK(args[0]->IsMap());
   Local<Map> map = args[0].As<Map>();
   (*histogram)->Percentiles([map, env](double key, int64_t value) {
@@ -548,7 +548,7 @@ void HistogramImpl::GetPercentiles(const FunctionCallbackInfo<Value>& args) {
 void HistogramImpl::GetPercentilesBigInt(
     const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-  HistogramImpl* histogram = HistogramImpl::FromJSObject(args.Holder());
+  HistogramImpl* histogram = HistogramImpl::FromJSObject(args.This());
   CHECK(args[0]->IsMap());
   Local<Map> map = args[0].As<Map>();
   (*histogram)->Percentiles([map, env](double key, int64_t value) {
@@ -560,7 +560,7 @@ void HistogramImpl::GetPercentilesBigInt(
 }
 
 void HistogramImpl::DoReset(const FunctionCallbackInfo<Value>& args) {
-  HistogramImpl* histogram = HistogramImpl::FromJSObject(args.Holder());
+  HistogramImpl* histogram = HistogramImpl::FromJSObject(args.This());
   (*histogram)->Reset();
 }
 

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -131,14 +131,14 @@ class JSBindingsConnection : public BaseObject {
 
   static void Disconnect(const FunctionCallbackInfo<Value>& info) {
     JSBindingsConnection* session;
-    ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&session, info.This());
     session->Disconnect();
   }
 
   static void Dispatch(const FunctionCallbackInfo<Value>& info) {
     Environment* env = Environment::GetCurrent(info);
     JSBindingsConnection* session;
-    ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&session, info.This());
     CHECK(info[0]->IsString());
 
     if (session->session_) {
@@ -206,7 +206,7 @@ void InspectorConsoleCall(const FunctionCallbackInfo<Value>& info) {
       env->set_is_in_inspector_console_call(true);
       MaybeLocal<Value> ret =
           inspector_method.As<Function>()->Call(context,
-                                                info.Holder(),
+                                                info.This(),
                                                 call_args.length(),
                                                 call_args.out());
       env->set_is_in_inspector_console_call(false);
@@ -218,7 +218,7 @@ void InspectorConsoleCall(const FunctionCallbackInfo<Value>& info) {
   Local<Value> node_method = info[1];
   CHECK(node_method->IsFunction());
   USE(node_method.As<Function>()->Call(context,
-                                   info.Holder(),
+                                   info.This(),
                                    call_args.length(),
                                    call_args.out()));
 }

--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -164,7 +164,7 @@ void JSStream::Finish(const FunctionCallbackInfo<Value>& args) {
 
 void JSStream::ReadBuffer(const FunctionCallbackInfo<Value>& args) {
   JSStream* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
 
   ArrayBufferViewContents<char> buffer(args[0]);
   const char* data = buffer.data();
@@ -194,7 +194,7 @@ void JSStream::ReadBuffer(const FunctionCallbackInfo<Value>& args) {
 
 void JSStream::EmitEOF(const FunctionCallbackInfo<Value>& args) {
   JSStream* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
 
   wrap->EmitRead(UV_EOF);
 }

--- a/src/js_udp_wrap.cc
+++ b/src/js_udp_wrap.cc
@@ -137,12 +137,12 @@ SocketAddress JSUDPWrap::GetSockName() {
 void JSUDPWrap::New(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   CHECK(args.IsConstructCall());
-  new JSUDPWrap(env, args.Holder());
+  new JSUDPWrap(env, args.This());
 }
 
 void JSUDPWrap::EmitReceived(const FunctionCallbackInfo<Value>& args) {
   JSUDPWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
   Environment* env = wrap->env();
 
   ArrayBufferViewContents<char> buffer(args[0]);
@@ -176,7 +176,7 @@ void JSUDPWrap::EmitReceived(const FunctionCallbackInfo<Value>& args) {
 
 void JSUDPWrap::OnSendDone(const FunctionCallbackInfo<Value>& args) {
   JSUDPWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
 
   CHECK(args[0]->IsObject());
   CHECK(args[1]->IsInt32());
@@ -189,7 +189,7 @@ void JSUDPWrap::OnSendDone(const FunctionCallbackInfo<Value>& args) {
 
 void JSUDPWrap::OnAfterBind(const FunctionCallbackInfo<Value>& args) {
   JSUDPWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
 
   wrap->listener()->OnAfterBind();
 }

--- a/src/node_blob.cc
+++ b/src/node_blob.cc
@@ -247,7 +247,7 @@ void Blob::New(const FunctionCallbackInfo<Value>& args) {
 void Blob::GetReader(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Blob* blob;
-  ASSIGN_OR_RETURN_UNWRAP(&blob, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&blob, args.This());
 
   BaseObjectPtr<Blob::Reader> reader =
       Blob::Reader::Create(env, BaseObjectPtr<Blob>(blob));
@@ -257,7 +257,7 @@ void Blob::GetReader(const FunctionCallbackInfo<Value>& args) {
 void Blob::ToSlice(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Blob* blob;
-  ASSIGN_OR_RETURN_UNWRAP(&blob, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&blob, args.This());
   CHECK(args[0]->IsUint32());
   CHECK(args[1]->IsUint32());
   size_t start = args[0].As<Uint32>()->Value();
@@ -326,7 +326,7 @@ BaseObjectPtr<Blob::Reader> Blob::Reader::Create(Environment* env,
 void Blob::Reader::Pull(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Blob::Reader* reader;
-  ASSIGN_OR_RETURN_UNWRAP(&reader, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&reader, args.This());
 
   CHECK(args[0]->IsFunction());
   Local<Function> fn = args[0].As<Function>();

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -994,7 +994,7 @@ void ContextifyScript::CreateCachedData(
     const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   ContextifyScript* wrapped_script;
-  ASSIGN_OR_RETURN_UNWRAP(&wrapped_script, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrapped_script, args.This());
   Local<UnboundScript> unbound_script =
       PersistentToLocal::Default(env->isolate(), wrapped_script->script_);
   std::unique_ptr<ScriptCompiler::CachedData> cached_data(
@@ -1014,7 +1014,7 @@ void ContextifyScript::RunInContext(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   ContextifyScript* wrapped_script;
-  ASSIGN_OR_RETURN_UNWRAP(&wrapped_script, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrapped_script, args.This());
 
   CHECK_EQ(args.Length(), 5);
   CHECK(args[0]->IsObject() || args[0]->IsNull());
@@ -1075,7 +1075,7 @@ bool ContextifyScript::EvalMachine(Local<Context> context,
 
   if (!env->can_call_into_js())
     return false;
-  if (!ContextifyScript::InstanceOf(env, args.Holder())) {
+  if (!ContextifyScript::InstanceOf(env, args.This())) {
     THROW_ERR_INVALID_THIS(
         env,
         "Script methods can only be called on script instances.");
@@ -1085,7 +1085,7 @@ bool ContextifyScript::EvalMachine(Local<Context> context,
   TryCatchScope try_catch(env);
   Isolate::SafeForTerminationScope safe_for_termination(env->isolate());
   ContextifyScript* wrapped_script;
-  ASSIGN_OR_RETURN_UNWRAP(&wrapped_script, args.Holder(), false);
+  ASSIGN_OR_RETURN_UNWRAP(&wrapped_script, args.This(), false);
   Local<UnboundScript> unbound_script =
       PersistentToLocal::Default(env->isolate(), wrapped_script->script_);
   Local<Script> script = unbound_script->BindToCurrentContext();

--- a/src/node_dir.cc
+++ b/src/node_dir.cc
@@ -187,7 +187,7 @@ void DirHandle::Close(const FunctionCallbackInfo<Value>& args) {
   CHECK_GE(argc, 1);
 
   DirHandle* dir;
-  ASSIGN_OR_RETURN_UNWRAP(&dir, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&dir, args.This());
 
   dir->closing_ = false;
   dir->closed_ = true;
@@ -288,7 +288,7 @@ void DirHandle::Read(const FunctionCallbackInfo<Value>& args) {
   const enum encoding encoding = ParseEncoding(isolate, args[0], UTF8);
 
   DirHandle* dir;
-  ASSIGN_OR_RETURN_UNWRAP(&dir, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&dir, args.This());
 
   CHECK(args[1]->IsNumber());
   uint64_t buffer_size = static_cast<uint64_t>(args[1].As<Number>()->Value());

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -502,7 +502,7 @@ MaybeLocal<Promise> FileHandle::ClosePromise() {
 
 void FileHandle::Close(const FunctionCallbackInfo<Value>& args) {
   FileHandle* fd;
-  ASSIGN_OR_RETURN_UNWRAP(&fd, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&fd, args.This());
   Local<Promise> ret;
   if (!fd->ClosePromise().ToLocal(&ret)) return;
   args.GetReturnValue().Set(ret);
@@ -511,7 +511,7 @@ void FileHandle::Close(const FunctionCallbackInfo<Value>& args) {
 
 void FileHandle::ReleaseFD(const FunctionCallbackInfo<Value>& args) {
   FileHandle* fd;
-  ASSIGN_OR_RETURN_UNWRAP(&fd, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&fd, args.This());
   fd->Release();
 }
 

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -2107,7 +2107,7 @@ void Http2Session::Consume(Local<Object> stream_obj) {
 // https://github.com/nodejs/node/issues/35475
 void Http2Session::Receive(const FunctionCallbackInfo<Value>& args) {
   Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&session, args.This());
   CHECK(args[0]->IsObject());
 
   ArrayBufferViewContents<char> buffer(args[0]);
@@ -2700,7 +2700,7 @@ void RefreshDefaultSettings(const FunctionCallbackInfo<Value>& args) {
 void Http2Session::SetNextStreamID(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&session, args.This());
   int32_t id = args[0]->Int32Value(env->context()).ToChecked();
   if (nghttp2_session_set_next_stream_id(session->session(), id) < 0) {
     Debug(session, "failed to set next stream id to %d", id);
@@ -2717,7 +2717,7 @@ void Http2Session::SetLocalWindowSize(
     const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&session, args.This());
 
   int32_t window_size = args[0]->Int32Value(env->context()).ToChecked();
 
@@ -2735,7 +2735,7 @@ void Http2Session::SetLocalWindowSize(
 template <get_setting fn, bool local>
 void Http2Session::RefreshSettings(const FunctionCallbackInfo<Value>& args) {
   Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&session, args.This());
   Http2Settings::Update(session, fn, local);
   Debug(session, "settings refreshed for session");
 }
@@ -2745,7 +2745,7 @@ void Http2Session::RefreshSettings(const FunctionCallbackInfo<Value>& args) {
 // TypedArray so those can be read in JS land.
 void Http2Session::RefreshState(const FunctionCallbackInfo<Value>& args) {
   Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&session, args.This());
   Debug(session, "refreshing state");
 
   AliasedFloat64Array& buffer = session->http2_state()->session_state_buffer;
@@ -2789,7 +2789,7 @@ void Http2Session::New(const FunctionCallbackInfo<Value>& args) {
 // Binds the Http2Session with a StreamBase used for i/o
 void Http2Session::Consume(const FunctionCallbackInfo<Value>& args) {
   Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&session, args.This());
   CHECK(args[0]->IsObject());
   session->Consume(args[0].As<Object>());
 }
@@ -2797,7 +2797,7 @@ void Http2Session::Consume(const FunctionCallbackInfo<Value>& args) {
 // Destroys the Http2Session instance and renders it unusable
 void Http2Session::Destroy(const FunctionCallbackInfo<Value>& args) {
   Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&session, args.This());
   Debug(session, "destroying session");
   Environment* env = Environment::GetCurrent(args);
   Local<Context> context = env->context();
@@ -2810,7 +2810,7 @@ void Http2Session::Destroy(const FunctionCallbackInfo<Value>& args) {
 // or the Http2Stream object.
 void Http2Session::Request(const FunctionCallbackInfo<Value>& args) {
   Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&session, args.This());
   Environment* env = session->env();
 
   Local<Array> headers = args[0].As<Array>();
@@ -2861,7 +2861,7 @@ void Http2Session::Goaway(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Local<Context> context = env->context();
   Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&session, args.This());
 
   uint32_t code = args[0]->Uint32Value(context).ToChecked();
   int32_t lastStreamID = args[1]->Int32Value(context).ToChecked();
@@ -2881,7 +2881,7 @@ void Http2Session::UpdateChunksSent(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = env->isolate();
   HandleScope scope(isolate);
   Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&session, args.This());
 
   uint32_t length = session->chunks_sent_since_last_write_;
 
@@ -2899,7 +2899,7 @@ void Http2Stream::RstStream(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Local<Context> context = env->context();
   Http2Stream* stream;
-  ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&stream, args.This());
   uint32_t code = args[0]->Uint32Value(context).ToChecked();
   Debug(stream, "sending rst_stream with code %d", code);
   stream->SubmitRstStream(code);
@@ -2910,7 +2910,7 @@ void Http2Stream::RstStream(const FunctionCallbackInfo<Value>& args) {
 void Http2Stream::Respond(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Http2Stream* stream;
-  ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&stream, args.This());
 
   Local<Array> headers = args[0].As<Array>();
   int32_t options = args[1]->Int32Value(env->context()).ToChecked();
@@ -2927,7 +2927,7 @@ void Http2Stream::Respond(const FunctionCallbackInfo<Value>& args) {
 void Http2Stream::Info(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Http2Stream* stream;
-  ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&stream, args.This());
 
   Local<Array> headers = args[0].As<Array>();
 
@@ -2938,7 +2938,7 @@ void Http2Stream::Info(const FunctionCallbackInfo<Value>& args) {
 void Http2Stream::Trailers(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Http2Stream* stream;
-  ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&stream, args.This());
 
   Local<Array> headers = args[0].As<Array>();
 
@@ -2949,14 +2949,14 @@ void Http2Stream::Trailers(const FunctionCallbackInfo<Value>& args) {
 // Grab the numeric id of the Http2Stream
 void Http2Stream::GetID(const FunctionCallbackInfo<Value>& args) {
   Http2Stream* stream;
-  ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&stream, args.This());
   args.GetReturnValue().Set(stream->id());
 }
 
 // Destroy the Http2Stream, rendering it no longer usable
 void Http2Stream::Destroy(const FunctionCallbackInfo<Value>& args) {
   Http2Stream* stream;
-  ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&stream, args.This());
   Debug(stream, "destroying stream");
   stream->Destroy();
 }
@@ -2965,7 +2965,7 @@ void Http2Stream::Destroy(const FunctionCallbackInfo<Value>& args) {
 void Http2Stream::PushPromise(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Http2Stream* parent;
-  ASSIGN_OR_RETURN_UNWRAP(&parent, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&parent, args.This());
 
   Local<Array> headers = args[0].As<Array>();
   int32_t options = args[1]->Int32Value(env->context()).ToChecked();
@@ -2991,7 +2991,7 @@ void Http2Stream::PushPromise(const FunctionCallbackInfo<Value>& args) {
 void Http2Stream::Priority(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Http2Stream* stream;
-  ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&stream, args.This());
 
   CHECK_EQ(stream->SubmitPriority(
       Http2Priority(env, args[0], args[1], args[2]),
@@ -3004,7 +3004,7 @@ void Http2Stream::Priority(const FunctionCallbackInfo<Value>& args) {
 // TypedArray so that the state can be read by JS.
 void Http2Stream::RefreshState(const FunctionCallbackInfo<Value>& args) {
   Http2Stream* stream;
-  ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&stream, args.This());
 
   Debug(stream, "refreshing state");
 
@@ -3061,7 +3061,7 @@ void Http2Session::Origin(const Origins& origins) {
 void Http2Session::AltSvc(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&session, args.This());
 
   int32_t id = args[0]->Int32Value(env->context()).ToChecked();
 
@@ -3092,7 +3092,7 @@ void Http2Session::Origin(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Local<Context> context = env->context();
   Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&session, args.This());
 
   Local<String> origin_string = args[0].As<String>();
   size_t count = args[1]->Int32Value(context).ToChecked();
@@ -3103,7 +3103,7 @@ void Http2Session::Origin(const FunctionCallbackInfo<Value>& args) {
 // Submits a PING frame to be sent to the connected peer.
 void Http2Session::Ping(const FunctionCallbackInfo<Value>& args) {
   Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&session, args.This());
 
   // A PING frame may have exactly 8 bytes of payload data. If not provided,
   // then the current hrtime will be used as the payload.
@@ -3121,7 +3121,7 @@ void Http2Session::Ping(const FunctionCallbackInfo<Value>& args) {
 // Submits a SETTINGS frame for the Http2Session
 void Http2Session::Settings(const FunctionCallbackInfo<Value>& args) {
   Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&session, args.This());
   CHECK(args[0]->IsFunction());
   args.GetReturnValue().Set(session->AddSettings(args[0].As<Function>()));
 }

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -563,7 +563,7 @@ class Parser : public AsyncWrap, public StreamListener {
 
   static void Close(const FunctionCallbackInfo<Value>& args) {
     Parser* parser;
-    ASSIGN_OR_RETURN_UNWRAP(&parser, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&parser, args.This());
 
     delete parser;
   }
@@ -571,7 +571,7 @@ class Parser : public AsyncWrap, public StreamListener {
 
   static void Free(const FunctionCallbackInfo<Value>& args) {
     Parser* parser;
-    ASSIGN_OR_RETURN_UNWRAP(&parser, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&parser, args.This());
 
     // Since the Parser destructor isn't going to run the destroy() callbacks
     // it needs to be triggered manually.
@@ -581,7 +581,7 @@ class Parser : public AsyncWrap, public StreamListener {
 
   static void Remove(const FunctionCallbackInfo<Value>& args) {
     Parser* parser;
-    ASSIGN_OR_RETURN_UNWRAP(&parser, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&parser, args.This());
 
     if (parser->connectionsList_ != nullptr) {
       parser->connectionsList_->Pop(parser);
@@ -605,7 +605,7 @@ class Parser : public AsyncWrap, public StreamListener {
   // var bytesParsed = parser->execute(buffer);
   static void Execute(const FunctionCallbackInfo<Value>& args) {
     Parser* parser;
-    ASSIGN_OR_RETURN_UNWRAP(&parser, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&parser, args.This());
 
     ArrayBufferViewContents<char> buffer(args[0]);
 
@@ -618,7 +618,7 @@ class Parser : public AsyncWrap, public StreamListener {
 
   static void Finish(const FunctionCallbackInfo<Value>& args) {
     Parser* parser;
-    ASSIGN_OR_RETURN_UNWRAP(&parser, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&parser, args.This());
 
     Local<Value> ret = parser->Execute(nullptr, 0);
 
@@ -661,7 +661,7 @@ class Parser : public AsyncWrap, public StreamListener {
 
     CHECK(type == HTTP_REQUEST || type == HTTP_RESPONSE);
     Parser* parser;
-    ASSIGN_OR_RETURN_UNWRAP(&parser, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&parser, args.This());
     // Should always be called from the same context.
     CHECK_EQ(env, parser->env());
 
@@ -695,7 +695,7 @@ class Parser : public AsyncWrap, public StreamListener {
   static void Pause(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args);
     Parser* parser;
-    ASSIGN_OR_RETURN_UNWRAP(&parser, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&parser, args.This());
     // Should always be called from the same context.
     CHECK_EQ(env, parser->env());
 
@@ -709,7 +709,7 @@ class Parser : public AsyncWrap, public StreamListener {
 
   static void Consume(const FunctionCallbackInfo<Value>& args) {
     Parser* parser;
-    ASSIGN_OR_RETURN_UNWRAP(&parser, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&parser, args.This());
     CHECK(args[0]->IsObject());
     StreamBase* stream = StreamBase::FromObject(args[0].As<Object>());
     CHECK_NOT_NULL(stream);
@@ -719,7 +719,7 @@ class Parser : public AsyncWrap, public StreamListener {
 
   static void Unconsume(const FunctionCallbackInfo<Value>& args) {
     Parser* parser;
-    ASSIGN_OR_RETURN_UNWRAP(&parser, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&parser, args.This());
 
     // Already unconsumed
     if (parser->stream_ == nullptr)
@@ -731,7 +731,7 @@ class Parser : public AsyncWrap, public StreamListener {
 
   static void GetCurrentBuffer(const FunctionCallbackInfo<Value>& args) {
     Parser* parser;
-    ASSIGN_OR_RETURN_UNWRAP(&parser, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&parser, args.This());
 
     Local<Object> ret = Buffer::Copy(
         parser->env(),
@@ -743,7 +743,7 @@ class Parser : public AsyncWrap, public StreamListener {
 
   static void Duration(const FunctionCallbackInfo<Value>& args) {
     Parser* parser;
-    ASSIGN_OR_RETURN_UNWRAP(&parser, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&parser, args.This());
 
     if (parser->last_message_start_ == 0) {
       args.GetReturnValue().Set(0);
@@ -756,7 +756,7 @@ class Parser : public AsyncWrap, public StreamListener {
 
   static void HeadersCompleted(const FunctionCallbackInfo<Value>& args) {
     Parser* parser;
-    ASSIGN_OR_RETURN_UNWRAP(&parser, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&parser, args.This());
 
     args.GetReturnValue().Set(parser->headers_completed_);
   }
@@ -1087,7 +1087,7 @@ void ConnectionsList::All(const FunctionCallbackInfo<Value>& args) {
 
   ConnectionsList* list;
 
-  ASSIGN_OR_RETURN_UNWRAP(&list, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&list, args.This());
 
   std::vector<Local<Value>> result;
   result.reserve(list->all_connections_.size());
@@ -1104,7 +1104,7 @@ void ConnectionsList::Idle(const FunctionCallbackInfo<Value>& args) {
 
   ConnectionsList* list;
 
-  ASSIGN_OR_RETURN_UNWRAP(&list, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&list, args.This());
 
   std::vector<Local<Value>> result;
   result.reserve(list->all_connections_.size());
@@ -1123,7 +1123,7 @@ void ConnectionsList::Active(const FunctionCallbackInfo<Value>& args) {
 
   ConnectionsList* list;
 
-  ASSIGN_OR_RETURN_UNWRAP(&list, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&list, args.This());
 
   std::vector<Local<Value>> result;
   result.reserve(list->active_connections_.size());
@@ -1140,7 +1140,7 @@ void ConnectionsList::Expired(const FunctionCallbackInfo<Value>& args) {
 
   ConnectionsList* list;
 
-  ASSIGN_OR_RETURN_UNWRAP(&list, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&list, args.This());
   CHECK(args[0]->IsNumber());
   CHECK(args[1]->IsNumber());
   uint64_t headers_timeout =

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -67,7 +67,7 @@ template <typename T, int (*F)(const typename T::HandleType*, sockaddr*, int*)>
 void GetSockOrPeerName(const v8::FunctionCallbackInfo<v8::Value>& args) {
   T* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
-                          args.Holder(),
+                          args.This(),
                           args.GetReturnValue().Set(UV_EBADF));
   CHECK(args[0]->IsObject());
   sockaddr_storage storage;

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -590,11 +590,11 @@ void BindingData::BigIntImpl(BindingData* receiver) {
 }
 
 void BindingData::SlowBigInt(const FunctionCallbackInfo<Value>& args) {
-  BigIntImpl(FromJSObject<BindingData>(args.Holder()));
+  BigIntImpl(FromJSObject<BindingData>(args.This()));
 }
 
 void BindingData::SlowNumber(const v8::FunctionCallbackInfo<v8::Value>& args) {
-  NumberImpl(FromJSObject<BindingData>(args.Holder()));
+  NumberImpl(FromJSObject<BindingData>(args.This()));
 }
 
 bool BindingData::PrepareForSerialization(Local<Context> context,

--- a/src/node_serdes.cc
+++ b/src/node_serdes.cc
@@ -180,13 +180,13 @@ void SerializerContext::New(const FunctionCallbackInfo<Value>& args) {
 
 void SerializerContext::WriteHeader(const FunctionCallbackInfo<Value>& args) {
   SerializerContext* ctx;
-  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.This());
   ctx->serializer_.WriteHeader();
 }
 
 void SerializerContext::WriteValue(const FunctionCallbackInfo<Value>& args) {
   SerializerContext* ctx;
-  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.This());
   Maybe<bool> ret =
       ctx->serializer_.WriteValue(ctx->env()->context(), args[0]);
 
@@ -196,7 +196,7 @@ void SerializerContext::WriteValue(const FunctionCallbackInfo<Value>& args) {
 void SerializerContext::SetTreatArrayBufferViewsAsHostObjects(
     const FunctionCallbackInfo<Value>& args) {
   SerializerContext* ctx;
-  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.This());
 
   bool value = args[0]->BooleanValue(ctx->env()->isolate());
   ctx->serializer_.SetTreatArrayBufferViewsAsHostObjects(value);
@@ -204,7 +204,7 @@ void SerializerContext::SetTreatArrayBufferViewsAsHostObjects(
 
 void SerializerContext::ReleaseBuffer(const FunctionCallbackInfo<Value>& args) {
   SerializerContext* ctx;
-  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.This());
 
   // Note: Both ValueSerializer and this Buffer::New() variant use malloc()
   // as the underlying allocator.
@@ -221,7 +221,7 @@ void SerializerContext::ReleaseBuffer(const FunctionCallbackInfo<Value>& args) {
 void SerializerContext::TransferArrayBuffer(
     const FunctionCallbackInfo<Value>& args) {
   SerializerContext* ctx;
-  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.This());
 
   Maybe<uint32_t> id = args[0]->Uint32Value(ctx->env()->context());
   if (id.IsNothing()) return;
@@ -237,7 +237,7 @@ void SerializerContext::TransferArrayBuffer(
 
 void SerializerContext::WriteUint32(const FunctionCallbackInfo<Value>& args) {
   SerializerContext* ctx;
-  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.This());
 
   Maybe<uint32_t> value = args[0]->Uint32Value(ctx->env()->context());
   if (value.IsNothing()) return;
@@ -247,7 +247,7 @@ void SerializerContext::WriteUint32(const FunctionCallbackInfo<Value>& args) {
 
 void SerializerContext::WriteUint64(const FunctionCallbackInfo<Value>& args) {
   SerializerContext* ctx;
-  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.This());
 
   Maybe<uint32_t> arg0 = args[0]->Uint32Value(ctx->env()->context());
   Maybe<uint32_t> arg1 = args[1]->Uint32Value(ctx->env()->context());
@@ -261,7 +261,7 @@ void SerializerContext::WriteUint64(const FunctionCallbackInfo<Value>& args) {
 
 void SerializerContext::WriteDouble(const FunctionCallbackInfo<Value>& args) {
   SerializerContext* ctx;
-  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.This());
 
   Maybe<double> value = args[0]->NumberValue(ctx->env()->context());
   if (value.IsNothing()) return;
@@ -271,7 +271,7 @@ void SerializerContext::WriteDouble(const FunctionCallbackInfo<Value>& args) {
 
 void SerializerContext::WriteRawBytes(const FunctionCallbackInfo<Value>& args) {
   SerializerContext* ctx;
-  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.This());
 
   if (!args[0]->IsArrayBufferView()) {
     return node::THROW_ERR_INVALID_ARG_TYPE(
@@ -339,7 +339,7 @@ void DeserializerContext::New(const FunctionCallbackInfo<Value>& args) {
 
 void DeserializerContext::ReadHeader(const FunctionCallbackInfo<Value>& args) {
   DeserializerContext* ctx;
-  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.This());
 
   Maybe<bool> ret = ctx->deserializer_.ReadHeader(ctx->env()->context());
 
@@ -348,7 +348,7 @@ void DeserializerContext::ReadHeader(const FunctionCallbackInfo<Value>& args) {
 
 void DeserializerContext::ReadValue(const FunctionCallbackInfo<Value>& args) {
   DeserializerContext* ctx;
-  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.This());
 
   MaybeLocal<Value> ret = ctx->deserializer_.ReadValue(ctx->env()->context());
 
@@ -358,7 +358,7 @@ void DeserializerContext::ReadValue(const FunctionCallbackInfo<Value>& args) {
 void DeserializerContext::TransferArrayBuffer(
     const FunctionCallbackInfo<Value>& args) {
   DeserializerContext* ctx;
-  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.This());
 
   Maybe<uint32_t> id = args[0]->Uint32Value(ctx->env()->context());
   if (id.IsNothing()) return;
@@ -382,14 +382,14 @@ void DeserializerContext::TransferArrayBuffer(
 void DeserializerContext::GetWireFormatVersion(
     const FunctionCallbackInfo<Value>& args) {
   DeserializerContext* ctx;
-  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.This());
 
   args.GetReturnValue().Set(ctx->deserializer_.GetWireFormatVersion());
 }
 
 void DeserializerContext::ReadUint32(const FunctionCallbackInfo<Value>& args) {
   DeserializerContext* ctx;
-  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.This());
 
   uint32_t value;
   bool ok = ctx->deserializer_.ReadUint32(&value);
@@ -399,7 +399,7 @@ void DeserializerContext::ReadUint32(const FunctionCallbackInfo<Value>& args) {
 
 void DeserializerContext::ReadUint64(const FunctionCallbackInfo<Value>& args) {
   DeserializerContext* ctx;
-  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.This());
 
   uint64_t value;
   bool ok = ctx->deserializer_.ReadUint64(&value);
@@ -419,7 +419,7 @@ void DeserializerContext::ReadUint64(const FunctionCallbackInfo<Value>& args) {
 
 void DeserializerContext::ReadDouble(const FunctionCallbackInfo<Value>& args) {
   DeserializerContext* ctx;
-  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.This());
 
   double value;
   bool ok = ctx->deserializer_.ReadDouble(&value);
@@ -430,7 +430,7 @@ void DeserializerContext::ReadDouble(const FunctionCallbackInfo<Value>& args) {
 void DeserializerContext::ReadRawBytes(
     const FunctionCallbackInfo<Value>& args) {
   DeserializerContext* ctx;
-  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.This());
 
   Maybe<int64_t> length_arg = args[0]->IntegerValue(ctx->env()->context());
   if (length_arg.IsNothing()) return;

--- a/src/node_sockaddr.cc
+++ b/src/node_sockaddr.cc
@@ -594,7 +594,7 @@ void SocketAddressBlockListWrap::AddAddress(
     const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   SocketAddressBlockListWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
 
   CHECK(SocketAddressBase::HasInstance(env, args[0]));
   SocketAddressBase* addr;
@@ -609,7 +609,7 @@ void SocketAddressBlockListWrap::AddRange(
     const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   SocketAddressBlockListWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
 
   CHECK(SocketAddressBase::HasInstance(env, args[0]));
   CHECK(SocketAddressBase::HasInstance(env, args[1]));
@@ -634,7 +634,7 @@ void SocketAddressBlockListWrap::AddSubnet(
     const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   SocketAddressBlockListWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
 
   CHECK(SocketAddressBase::HasInstance(env, args[0]));
   CHECK(args[1]->IsInt32());
@@ -660,7 +660,7 @@ void SocketAddressBlockListWrap::Check(
     const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   SocketAddressBlockListWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
 
   CHECK(SocketAddressBase::HasInstance(env, args[0]));
   SocketAddressBase* addr;
@@ -673,7 +673,7 @@ void SocketAddressBlockListWrap::GetRules(
     const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   SocketAddressBlockListWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
   Local<Array> rules;
   if (wrap->blocklist_->ListRules(env).ToLocal(&rules))
     args.GetReturnValue().Set(rules);
@@ -814,7 +814,7 @@ void SocketAddressBase::Detail(const FunctionCallbackInfo<Value>& args) {
   Local<Object> detail = args[0].As<Object>();
 
   SocketAddressBase* base;
-  ASSIGN_OR_RETURN_UNWRAP(&base, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&base, args.This());
 
   Local<Value> address;
   if (!ToV8Value(env->context(), base->address_->address()).ToLocal(&address))
@@ -840,14 +840,14 @@ void SocketAddressBase::Detail(const FunctionCallbackInfo<Value>& args) {
 
 void SocketAddressBase::GetFlowLabel(const FunctionCallbackInfo<Value>& args) {
   SocketAddressBase* base;
-  ASSIGN_OR_RETURN_UNWRAP(&base, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&base, args.This());
   args.GetReturnValue().Set(base->address_->flow_label());
 }
 
 void SocketAddressBase::LegacyDetail(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   SocketAddressBase* base;
-  ASSIGN_OR_RETURN_UNWRAP(&base, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&base, args.This());
   Local<Object> address;
   if (!base->address_->ToJS(env).ToLocal(&address)) return;
   args.GetReturnValue().Set(address);

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -107,7 +107,7 @@ void StatWatcher::Start(const FunctionCallbackInfo<Value>& args) {
   CHECK_EQ(args.Length(), 2);
 
   StatWatcher* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
   CHECK(!uv_is_active(wrap->GetHandle()));
 
   node::Utf8Value path(args.GetIsolate(), args[0]);

--- a/src/node_trace_events.cc
+++ b/src/node_trace_events.cc
@@ -77,7 +77,7 @@ void NodeCategorySet::New(const FunctionCallbackInfo<Value>& args) {
 
 void NodeCategorySet::Enable(const FunctionCallbackInfo<Value>& args) {
   NodeCategorySet* category_set;
-  ASSIGN_OR_RETURN_UNWRAP(&category_set, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&category_set, args.This());
   CHECK_NOT_NULL(category_set);
   const auto& categories = category_set->GetCategories();
   if (!category_set->enabled_ && !categories.empty()) {
@@ -91,7 +91,7 @@ void NodeCategorySet::Enable(const FunctionCallbackInfo<Value>& args) {
 
 void NodeCategorySet::Disable(const FunctionCallbackInfo<Value>& args) {
   NodeCategorySet* category_set;
-  ASSIGN_OR_RETURN_UNWRAP(&category_set, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&category_set, args.This());
   CHECK_NOT_NULL(category_set);
   const auto& categories = category_set->GetCategories();
   if (category_set->enabled_ && !categories.empty()) {

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -369,7 +369,7 @@ void GCProfiler::New(const FunctionCallbackInfo<Value>& args) {
 void GCProfiler::Start(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   GCProfiler* profiler;
-  ASSIGN_OR_RETURN_UNWRAP(&profiler, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&profiler, args.This());
   if (profiler->state != GCProfiler::GCProfilerState::kInitialized) {
     return;
   }
@@ -394,7 +394,7 @@ void GCProfiler::Start(const FunctionCallbackInfo<Value>& args) {
 void GCProfiler::Stop(const FunctionCallbackInfo<v8::Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   GCProfiler* profiler;
-  ASSIGN_OR_RETURN_UNWRAP(&profiler, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&profiler, args.This());
   if (profiler->state != GCProfiler::GCProfilerState::kStarted) {
     return;
   }

--- a/src/node_wasm_web_api.cc
+++ b/src/node_wasm_web_api.cc
@@ -81,7 +81,7 @@ void WasmStreamingObject::New(const FunctionCallbackInfo<Value>& args) {
 
 void WasmStreamingObject::SetURL(const FunctionCallbackInfo<Value>& args) {
   WasmStreamingObject* obj;
-  ASSIGN_OR_RETURN_UNWRAP(&obj, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&obj, args.This());
   CHECK(obj->streaming_);
 
   CHECK_EQ(args.Length(), 1);
@@ -92,7 +92,7 @@ void WasmStreamingObject::SetURL(const FunctionCallbackInfo<Value>& args) {
 
 void WasmStreamingObject::Push(const FunctionCallbackInfo<Value>& args) {
   WasmStreamingObject* obj;
-  ASSIGN_OR_RETURN_UNWRAP(&obj, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&obj, args.This());
   CHECK(obj->streaming_);
 
   CHECK_EQ(args.Length(), 1);
@@ -128,7 +128,7 @@ void WasmStreamingObject::Push(const FunctionCallbackInfo<Value>& args) {
 
 void WasmStreamingObject::Finish(const FunctionCallbackInfo<Value>& args) {
   WasmStreamingObject* obj;
-  ASSIGN_OR_RETURN_UNWRAP(&obj, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&obj, args.This());
   CHECK(obj->streaming_);
 
   CHECK_EQ(args.Length(), 0);
@@ -137,7 +137,7 @@ void WasmStreamingObject::Finish(const FunctionCallbackInfo<Value>& args) {
 
 void WasmStreamingObject::Abort(const FunctionCallbackInfo<Value>& args) {
   WasmStreamingObject* obj;
-  ASSIGN_OR_RETURN_UNWRAP(&obj, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&obj, args.This());
   CHECK(obj->streaming_);
 
   CHECK_EQ(args.Length(), 1);

--- a/src/node_watchdog.cc
+++ b/src/node_watchdog.cc
@@ -147,7 +147,7 @@ void TraceSigintWatchdog::New(const FunctionCallbackInfo<Value>& args) {
 
 void TraceSigintWatchdog::Start(const FunctionCallbackInfo<Value>& args) {
   TraceSigintWatchdog* watchdog;
-  ASSIGN_OR_RETURN_UNWRAP(&watchdog, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&watchdog, args.This());
   Mutex::ScopedLock lock(SigintWatchdogHelper::GetInstanceActionMutex());
   // Register this watchdog with the global SIGINT/Ctrl+C listener.
   SigintWatchdogHelper::GetInstance()->Register(watchdog);
@@ -158,7 +158,7 @@ void TraceSigintWatchdog::Start(const FunctionCallbackInfo<Value>& args) {
 
 void TraceSigintWatchdog::Stop(const FunctionCallbackInfo<Value>& args) {
   TraceSigintWatchdog* watchdog;
-  ASSIGN_OR_RETURN_UNWRAP(&watchdog, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&watchdog, args.This());
   Mutex::ScopedLock lock(SigintWatchdogHelper::GetInstanceActionMutex());
   SigintWatchdogHelper::GetInstance()->Unregister(watchdog);
   SigintWatchdogHelper::GetInstance()->Stop();

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -288,7 +288,7 @@ class CompressionStream : public AsyncWrap, public ThreadPoolWork {
 
   static void Close(const FunctionCallbackInfo<Value>& args) {
     CompressionStream* ctx;
-    ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&ctx, args.This());
     ctx->Close();
   }
 
@@ -339,7 +339,7 @@ class CompressionStream : public AsyncWrap, public ThreadPoolWork {
     out = Buffer::Data(out_buf) + out_off;
 
     CompressionStream* ctx;
-    ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&ctx, args.This());
 
     ctx->Write<async>(flush, in, in_len, out, out_len);
   }
@@ -453,7 +453,7 @@ class CompressionStream : public AsyncWrap, public ThreadPoolWork {
 
   static void Reset(const FunctionCallbackInfo<Value> &args) {
     CompressionStream* wrap;
-    ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
 
     AllocScope alloc_scope(wrap);
     const CompressionError err = wrap->context()->ResetStream();
@@ -585,7 +585,7 @@ class ZlibStream final : public CompressionStream<ZlibContext> {
       " dictionary)");
 
     ZlibStream* wrap;
-    ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
 
     Local<Context> context = args.GetIsolate()->GetCurrentContext();
 
@@ -633,7 +633,7 @@ class ZlibStream final : public CompressionStream<ZlibContext> {
   static void Params(const FunctionCallbackInfo<Value>& args) {
     CHECK(args.Length() == 2 && "params(level, strategy)");
     ZlibStream* wrap;
-    ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
     Local<Context> context = args.GetIsolate()->GetCurrentContext();
     int level;
     if (!args[0]->Int32Value(context).To(&level)) return;
@@ -676,7 +676,7 @@ class BrotliCompressionStream final :
 
   static void Init(const FunctionCallbackInfo<Value>& args) {
     BrotliCompressionStream* wrap;
-    ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
     CHECK(args.Length() == 3 && "init(params, writeResult, writeCallback)");
 
     CHECK(args[1]->IsUint32Array());

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -160,7 +160,7 @@ PipeWrap::PipeWrap(Environment* env,
 
 void PipeWrap::Bind(const FunctionCallbackInfo<Value>& args) {
   PipeWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
   node::Utf8Value name(args.GetIsolate(), args[0]);
   int err = uv_pipe_bind2(&wrap->handle_, *name, name.length(), 0);
   args.GetReturnValue().Set(err);
@@ -169,7 +169,7 @@ void PipeWrap::Bind(const FunctionCallbackInfo<Value>& args) {
 #ifdef _WIN32
 void PipeWrap::SetPendingInstances(const FunctionCallbackInfo<Value>& args) {
   PipeWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
   CHECK(args[0]->IsInt32());
   int instances = args[0].As<Int32>()->Value();
   uv_pipe_pending_instances(&wrap->handle_, instances);
@@ -178,7 +178,7 @@ void PipeWrap::SetPendingInstances(const FunctionCallbackInfo<Value>& args) {
 
 void PipeWrap::Fchmod(const v8::FunctionCallbackInfo<v8::Value>& args) {
   PipeWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
   CHECK(args[0]->IsInt32());
   int mode = args[0].As<Int32>()->Value();
   int err = uv_pipe_chmod(&wrap->handle_, mode);
@@ -187,7 +187,7 @@ void PipeWrap::Fchmod(const v8::FunctionCallbackInfo<v8::Value>& args) {
 
 void PipeWrap::Listen(const FunctionCallbackInfo<Value>& args) {
   PipeWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
   Environment* env = wrap->env();
   int backlog;
   if (!args[0]->Int32Value(env->context()).To(&backlog)) return;
@@ -200,7 +200,7 @@ void PipeWrap::Open(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   PipeWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
 
   int fd;
   if (!args[0]->Int32Value(env->context()).To(&fd)) return;
@@ -215,7 +215,7 @@ void PipeWrap::Connect(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   PipeWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
 
   CHECK(args[0]->IsObject());
   CHECK(args[1]->IsString());

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -154,7 +154,7 @@ class ProcessWrap : public HandleWrap {
     Environment* env = Environment::GetCurrent(args);
     Local<Context> context = env->context();
     ProcessWrap* wrap;
-    ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
     THROW_IF_INSUFFICIENT_PERMISSIONS(
         env, permission::PermissionScope::kChildProcess, "");
     int err = 0;
@@ -310,7 +310,7 @@ class ProcessWrap : public HandleWrap {
   static void Kill(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args);
     ProcessWrap* wrap;
-    ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
     int signal = args[0]->Int32Value(env->context()).FromJust();
     int err = uv_process_kill(&wrap->process_, signal);
     args.GetReturnValue().Set(err);

--- a/src/quic/endpoint.cc
+++ b/src/quic/endpoint.cc
@@ -1690,7 +1690,7 @@ void Endpoint::New(const FunctionCallbackInfo<Value>& args) {
 void Endpoint::DoConnect(const FunctionCallbackInfo<Value>& args) {
   auto env = Environment::GetCurrent(args);
   Endpoint* endpoint;
-  ASSIGN_OR_RETURN_UNWRAP(&endpoint, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&endpoint, args.This());
 
   // args[0] is a SocketAddress
   // args[1] is a Session OptionsObject (see session.cc)
@@ -1723,7 +1723,7 @@ void Endpoint::DoConnect(const FunctionCallbackInfo<Value>& args) {
 
 void Endpoint::DoListen(const FunctionCallbackInfo<Value>& args) {
   Endpoint* endpoint;
-  ASSIGN_OR_RETURN_UNWRAP(&endpoint, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&endpoint, args.This());
   auto env = Environment::GetCurrent(args);
 
   Session::Options options;
@@ -1734,20 +1734,20 @@ void Endpoint::DoListen(const FunctionCallbackInfo<Value>& args) {
 
 void Endpoint::MarkBusy(const FunctionCallbackInfo<Value>& args) {
   Endpoint* endpoint;
-  ASSIGN_OR_RETURN_UNWRAP(&endpoint, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&endpoint, args.This());
   endpoint->MarkAsBusy(args[0]->IsTrue());
 }
 
 void Endpoint::DoCloseGracefully(const FunctionCallbackInfo<Value>& args) {
   Endpoint* endpoint;
-  ASSIGN_OR_RETURN_UNWRAP(&endpoint, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&endpoint, args.This());
   endpoint->CloseGracefully();
 }
 
 void Endpoint::LocalAddress(const FunctionCallbackInfo<Value>& args) {
   auto env = Environment::GetCurrent(args);
   Endpoint* endpoint;
-  ASSIGN_OR_RETURN_UNWRAP(&endpoint, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&endpoint, args.This());
   if (endpoint->is_closed() || !endpoint->udp_.is_bound()) return;
   auto addr = SocketAddressBase::Create(
       env, std::make_shared<SocketAddress>(endpoint->local_address()));
@@ -1756,7 +1756,7 @@ void Endpoint::LocalAddress(const FunctionCallbackInfo<Value>& args) {
 
 void Endpoint::Ref(const FunctionCallbackInfo<Value>& args) {
   Endpoint* endpoint;
-  ASSIGN_OR_RETURN_UNWRAP(&endpoint, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&endpoint, args.This());
   auto env = Environment::GetCurrent(args);
   if (args[0]->BooleanValue(env->isolate())) {
     endpoint->udp_.Ref();

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -1753,14 +1753,14 @@ struct Session::Impl {
 
   static void DoDestroy(const FunctionCallbackInfo<Value>& args) {
     Session* session;
-    ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&session, args.This());
     session->Destroy();
   }
 
   static void GetRemoteAddress(const FunctionCallbackInfo<Value>& args) {
     auto env = Environment::GetCurrent(args);
     Session* session;
-    ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&session, args.This());
     auto address = session->remote_address();
     args.GetReturnValue().Set(
         SocketAddressBase::Create(env, std::make_shared<SocketAddress>(address))
@@ -1770,7 +1770,7 @@ struct Session::Impl {
   static void GetCertificate(const FunctionCallbackInfo<Value>& args) {
     auto env = Environment::GetCurrent(args);
     Session* session;
-    ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&session, args.This());
     Local<Value> ret;
     if (session->tls_session().cert(env).ToLocal(&ret))
       args.GetReturnValue().Set(ret);
@@ -1779,7 +1779,7 @@ struct Session::Impl {
   static void GetEphemeralKeyInfo(const FunctionCallbackInfo<Value>& args) {
     auto env = Environment::GetCurrent(args);
     Session* session;
-    ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&session, args.This());
     Local<Object> ret;
     if (!session->is_server() &&
         session->tls_session().ephemeral_key(env).ToLocal(&ret))
@@ -1789,7 +1789,7 @@ struct Session::Impl {
   static void GetPeerCertificate(const FunctionCallbackInfo<Value>& args) {
     auto env = Environment::GetCurrent(args);
     Session* session;
-    ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&session, args.This());
     Local<Value> ret;
     if (session->tls_session().peer_cert(env).ToLocal(&ret))
       args.GetReturnValue().Set(ret);
@@ -1797,20 +1797,20 @@ struct Session::Impl {
 
   static void GracefulClose(const FunctionCallbackInfo<Value>& args) {
     Session* session;
-    ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&session, args.This());
     session->Close(Session::CloseMethod::GRACEFUL);
   }
 
   static void SilentClose(const FunctionCallbackInfo<Value>& args) {
     // This is exposed for testing purposes only!
     Session* session;
-    ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&session, args.This());
     session->Close(Session::CloseMethod::SILENT);
   }
 
   static void UpdateKey(const FunctionCallbackInfo<Value>& args) {
     Session* session;
-    ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&session, args.This());
     // Initiating a key update may fail if it is done too early (either
     // before the TLS handshake has been confirmed or while a previous
     // key update is being processed). When it fails, InitiateKeyUpdate()
@@ -1821,7 +1821,7 @@ struct Session::Impl {
 
   static void DoOpenStream(const FunctionCallbackInfo<Value>& args) {
     Session* session;
-    ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&session, args.This());
     DCHECK(args[0]->IsUint32());
     auto direction = static_cast<Direction>(args[0].As<Uint32>()->Value());
     BaseObjectPtr<Stream> stream = session->OpenStream(direction);
@@ -1832,7 +1832,7 @@ struct Session::Impl {
   static void DoSendDatagram(const FunctionCallbackInfo<Value>& args) {
     auto env = Environment::GetCurrent(args);
     Session* session;
-    ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&session, args.This());
     DCHECK(args[0]->IsArrayBufferView());
     args.GetReturnValue().Set(BigInt::New(
         env->isolate(),

--- a/src/quic/streams.cc
+++ b/src/quic/streams.cc
@@ -128,14 +128,14 @@ struct Stream::Impl {
     std::shared_ptr<DataQueue> dataqueue;
     if (GetDataQueueFromSource(env, args[0]).To(&dataqueue)) {
       Stream* stream;
-      ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
+      ASSIGN_OR_RETURN_UNWRAP(&stream, args.This());
       stream->set_outbound(std::move(dataqueue));
     }
   }
 
   static void Destroy(const FunctionCallbackInfo<Value>& args) {
     Stream* stream;
-    ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&stream, args.This());
     if (args.Length() > 1) {
       CHECK(args[0]->IsBigInt());
       bool unused = false;
@@ -148,7 +148,7 @@ struct Stream::Impl {
 
   static void SendHeaders(const FunctionCallbackInfo<Value>& args) {
     Stream* stream;
-    ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&stream, args.This());
     CHECK(args[0]->IsUint32());  // Kind
     CHECK(args[1]->IsArray());   // Headers
     CHECK(args[2]->IsUint32());  // Flags
@@ -169,7 +169,7 @@ struct Stream::Impl {
   // that has already been received is still readable.
   static void StopSending(const FunctionCallbackInfo<Value>& args) {
     Stream* stream;
-    ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&stream, args.This());
     uint64_t code = NGTCP2_APP_NOERROR;
     CHECK_IMPLIES(!args[0]->IsUndefined(), args[0]->IsBigInt());
     if (!args[0]->IsUndefined()) {
@@ -189,7 +189,7 @@ struct Stream::Impl {
   // outbound queue will be dropped. The stream may still be readable.
   static void ResetStream(const FunctionCallbackInfo<Value>& args) {
     Stream* stream;
-    ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&stream, args.This());
     uint64_t code = NGTCP2_APP_NOERROR;
     CHECK_IMPLIES(!args[0]->IsUndefined(), args[0]->IsBigInt());
     if (!args[0]->IsUndefined()) {
@@ -210,7 +210,7 @@ struct Stream::Impl {
 
   static void SetPriority(const FunctionCallbackInfo<Value>& args) {
     Stream* stream;
-    ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&stream, args.This());
     CHECK(args[0]->IsUint32());  // Priority
     CHECK(args[1]->IsUint32());  // Priority flag
 
@@ -224,14 +224,14 @@ struct Stream::Impl {
 
   static void GetPriority(const FunctionCallbackInfo<Value>& args) {
     Stream* stream;
-    ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&stream, args.This());
     auto priority = stream->session().application().GetStreamPriority(*stream);
     args.GetReturnValue().Set(static_cast<uint32_t>(priority));
   }
 
   static void GetReader(const FunctionCallbackInfo<Value>& args) {
     Stream* stream;
-    ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&stream, args.This());
     BaseObjectPtr<Blob::Reader> reader = stream->get_reader();
     if (reader) return args.GetReturnValue().Set(reader->object());
     THROW_ERR_INVALID_STATE(Environment::GetCurrent(args),

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -104,7 +104,7 @@ class SignalWrap : public HandleWrap {
 
   static void Start(const FunctionCallbackInfo<Value>& args) {
     SignalWrap* wrap;
-    ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
     Environment* env = wrap->env();
     int signum;
     if (!args[0]->Int32Value(env->context()).To(&signum)) return;
@@ -142,7 +142,7 @@ class SignalWrap : public HandleWrap {
 
   static void Stop(const FunctionCallbackInfo<Value>& args) {
     SignalWrap* wrap;
-    ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+    ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
 
     if (wrap->active_)  {
       wrap->active_ = false;

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -632,7 +632,7 @@ void StreamBase::GetExternal(const FunctionCallbackInfo<Value>& args) {
 
 template <int (StreamBase::*Method)(const FunctionCallbackInfo<Value>& args)>
 void StreamBase::JSMethod(const FunctionCallbackInfo<Value>& args) {
-  StreamBase* wrap = StreamBase::FromObject(args.Holder().As<Object>());
+  StreamBase* wrap = StreamBase::FromObject(args.This().As<Object>());
   if (wrap == nullptr) return;
 
   if (!wrap->IsAlive()) return args.GetReturnValue().Set(UV_EINVAL);

--- a/src/stream_pipe.cc
+++ b/src/stream_pipe.cc
@@ -284,26 +284,26 @@ void StreamPipe::New(const FunctionCallbackInfo<Value>& args) {
 
 void StreamPipe::Start(const FunctionCallbackInfo<Value>& args) {
   StreamPipe* pipe;
-  ASSIGN_OR_RETURN_UNWRAP(&pipe, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&pipe, args.This());
   pipe->is_closed_ = false;
   pipe->writable_listener_.OnStreamWantsWrite(65536);
 }
 
 void StreamPipe::Unpipe(const FunctionCallbackInfo<Value>& args) {
   StreamPipe* pipe;
-  ASSIGN_OR_RETURN_UNWRAP(&pipe, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&pipe, args.This());
   pipe->Unpipe();
 }
 
 void StreamPipe::IsClosed(const FunctionCallbackInfo<Value>& args) {
   StreamPipe* pipe;
-  ASSIGN_OR_RETURN_UNWRAP(&pipe, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&pipe, args.This());
   args.GetReturnValue().Set(pipe->is_closed_);
 }
 
 void StreamPipe::PendingWrites(const FunctionCallbackInfo<Value>& args) {
   StreamPipe* pipe;
-  ASSIGN_OR_RETURN_UNWRAP(&pipe, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&pipe, args.This());
   args.GetReturnValue().Set(pipe->pending_writes_);
 }
 

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -311,7 +311,7 @@ void LibuvStreamWrap::GetWriteQueueSize(
 
 void LibuvStreamWrap::SetBlocking(const FunctionCallbackInfo<Value>& args) {
   LibuvStreamWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
 
   CHECK_GT(args.Length(), 0);
   if (!wrap->IsAlive())

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -185,7 +185,7 @@ TCPWrap::TCPWrap(Environment* env, Local<Object> object, ProviderType provider)
 void TCPWrap::SetNoDelay(const FunctionCallbackInfo<Value>& args) {
   TCPWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
-                          args.Holder(),
+                          args.This(),
                           args.GetReturnValue().Set(UV_EBADF));
   int enable = static_cast<int>(args[0]->IsTrue());
   int err = uv_tcp_nodelay(&wrap->handle_, enable);
@@ -196,7 +196,7 @@ void TCPWrap::SetNoDelay(const FunctionCallbackInfo<Value>& args) {
 void TCPWrap::SetKeepAlive(const FunctionCallbackInfo<Value>& args) {
   TCPWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
-                          args.Holder(),
+                          args.This(),
                           args.GetReturnValue().Set(UV_EBADF));
   Environment* env = wrap->env();
   int enable;
@@ -211,7 +211,7 @@ void TCPWrap::SetKeepAlive(const FunctionCallbackInfo<Value>& args) {
 void TCPWrap::SetSimultaneousAccepts(const FunctionCallbackInfo<Value>& args) {
   TCPWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
-                          args.Holder(),
+                          args.This(),
                           args.GetReturnValue().Set(UV_EBADF));
   bool enable = args[0]->IsTrue();
   int err = uv_tcp_simultaneous_accepts(&wrap->handle_, enable);
@@ -223,7 +223,7 @@ void TCPWrap::SetSimultaneousAccepts(const FunctionCallbackInfo<Value>& args) {
 void TCPWrap::Open(const FunctionCallbackInfo<Value>& args) {
   TCPWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
-                          args.Holder(),
+                          args.This(),
                           args.GetReturnValue().Set(UV_EBADF));
   int64_t val;
   if (!args[0]->IntegerValue(args.GetIsolate()->GetCurrentContext()).To(&val))
@@ -244,7 +244,7 @@ void TCPWrap::Bind(
     std::function<int(const char* ip_address, int port, T* addr)> uv_ip_addr) {
   TCPWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
-                          args.Holder(),
+                          args.This(),
                           args.GetReturnValue().Set(UV_EBADF));
   Environment* env = wrap->env();
   node::Utf8Value ip_address(env->isolate(), args[0]);
@@ -280,7 +280,7 @@ void TCPWrap::Bind6(const FunctionCallbackInfo<Value>& args) {
 void TCPWrap::Listen(const FunctionCallbackInfo<Value>& args) {
   TCPWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
-                          args.Holder(),
+                          args.This(),
                           args.GetReturnValue().Set(UV_EBADF));
   Environment* env = wrap->env();
   int backlog;
@@ -321,7 +321,7 @@ void TCPWrap::Connect(const FunctionCallbackInfo<Value>& args,
 
   TCPWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
-                          args.Holder(),
+                          args.This(),
                           args.GetReturnValue().Set(UV_EBADF));
 
   CHECK(args[0]->IsObject());
@@ -361,7 +361,7 @@ void TCPWrap::Connect(const FunctionCallbackInfo<Value>& args,
 void TCPWrap::Reset(const FunctionCallbackInfo<Value>& args) {
   TCPWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(
-      &wrap, args.Holder(), args.GetReturnValue().Set(UV_EBADF));
+      &wrap, args.This(), args.GetReturnValue().Set(UV_EBADF));
 
   int err = wrap->Reset(args[0]);
 

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -92,7 +92,7 @@ void TTYWrap::GetWindowSize(const FunctionCallbackInfo<Value>& args) {
 
   TTYWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
-                          args.Holder(),
+                          args.This(),
                           args.GetReturnValue().Set(UV_EBADF));
   CHECK(args[0]->IsArray());
 
@@ -112,7 +112,7 @@ void TTYWrap::GetWindowSize(const FunctionCallbackInfo<Value>& args) {
 void TTYWrap::SetRawMode(const FunctionCallbackInfo<Value>& args) {
   TTYWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
-                          args.Holder(),
+                          args.This(),
                           args.GetReturnValue().Set(UV_EBADF));
   int err = uv_tty_set_mode(&wrap->handle_, args[0]->IsTrue());
   args.GetReturnValue().Set(err);

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -56,7 +56,7 @@ using v8::Value;
 namespace {
 template <int (*fn)(uv_udp_t*, int)>
 void SetLibuvInt32(const FunctionCallbackInfo<Value>& args) {
-  UDPWrap* wrap = Unwrap<UDPWrap>(args.Holder());
+  UDPWrap* wrap = Unwrap<UDPWrap>(args.This());
   if (wrap == nullptr) {
     args.GetReturnValue().Set(UV_EBADF);
     return;
@@ -299,7 +299,7 @@ int sockaddr_for_family(int address_family,
 void UDPWrap::DoBind(const FunctionCallbackInfo<Value>& args, int family) {
   UDPWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
-                          args.Holder(),
+                          args.This(),
                           args.GetReturnValue().Set(UV_EBADF));
 
   // bind(ip, port, flags)
@@ -329,7 +329,7 @@ void UDPWrap::DoBind(const FunctionCallbackInfo<Value>& args, int family) {
 void UDPWrap::DoConnect(const FunctionCallbackInfo<Value>& args, int family) {
   UDPWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
-                          args.Holder(),
+                          args.This(),
                           args.GetReturnValue().Set(UV_EBADF));
 
   CHECK_EQ(args.Length(), 2);
@@ -353,7 +353,7 @@ void UDPWrap::DoConnect(const FunctionCallbackInfo<Value>& args, int family) {
 void UDPWrap::Open(const FunctionCallbackInfo<Value>& args) {
   UDPWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
-                          args.Holder(),
+                          args.This(),
                           args.GetReturnValue().Set(UV_EBADF));
   CHECK(args[0]->IsNumber());
   int fd = static_cast<int>(args[0].As<Integer>()->Value());
@@ -377,7 +377,7 @@ void UDPWrap::BufferSize(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   UDPWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
-                          args.Holder(),
+                          args.This(),
                           args.GetReturnValue().Set(UV_EBADF));
 
   CHECK(args[0]->IsUint32());
@@ -422,7 +422,7 @@ void UDPWrap::Connect6(const FunctionCallbackInfo<Value>& args) {
 void UDPWrap::Disconnect(const FunctionCallbackInfo<Value>& args) {
   UDPWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
-                          args.Holder(),
+                          args.This(),
                           args.GetReturnValue().Set(UV_EBADF));
 
   CHECK_EQ(args.Length(), 0);
@@ -435,7 +435,7 @@ void UDPWrap::Disconnect(const FunctionCallbackInfo<Value>& args) {
 void UDPWrap::SetMulticastInterface(const FunctionCallbackInfo<Value>& args) {
   UDPWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
-                          args.Holder(),
+                          args.This(),
                           args.GetReturnValue().Set(UV_EBADF));
 
   CHECK_EQ(args.Length(), 1);
@@ -453,7 +453,7 @@ void UDPWrap::SetMembership(const FunctionCallbackInfo<Value>& args,
                             uv_membership membership) {
   UDPWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
-                          args.Holder(),
+                          args.This(),
                           args.GetReturnValue().Set(UV_EBADF));
 
   CHECK_EQ(args.Length(), 2);
@@ -487,7 +487,7 @@ void UDPWrap::SetSourceMembership(const FunctionCallbackInfo<Value>& args,
                                   uv_membership membership) {
   UDPWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
-                          args.Holder(),
+                          args.This(),
                           args.GetReturnValue().Set(UV_EBADF));
 
   CHECK_EQ(args.Length(), 3);
@@ -527,7 +527,7 @@ void UDPWrap::DoSend(const FunctionCallbackInfo<Value>& args, int family) {
 
   UDPWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
-                          args.Holder(),
+                          args.This(),
                           args.GetReturnValue().Set(UV_EBADF));
 
   CHECK(args.Length() == 4 || args.Length() == 6);
@@ -678,7 +678,7 @@ SocketAddress UDPWrap::GetSockName() {
 }
 
 void UDPWrapBase::RecvStart(const FunctionCallbackInfo<Value>& args) {
-  UDPWrapBase* wrap = UDPWrapBase::FromObject(args.Holder());
+  UDPWrapBase* wrap = UDPWrapBase::FromObject(args.This());
   args.GetReturnValue().Set(wrap == nullptr ? UV_EBADF : wrap->RecvStart());
 }
 
@@ -693,7 +693,7 @@ int UDPWrap::RecvStart() {
 
 
 void UDPWrapBase::RecvStop(const FunctionCallbackInfo<Value>& args) {
-  UDPWrapBase* wrap = UDPWrapBase::FromObject(args.Holder());
+  UDPWrapBase* wrap = UDPWrapBase::FromObject(args.This());
   args.GetReturnValue().Set(wrap == nullptr ? UV_EBADF : wrap->RecvStop());
 }
 
@@ -828,7 +828,7 @@ MaybeLocal<Object> UDPWrap::Instantiate(Environment* env,
 void UDPWrap::GetSendQueueSize(const FunctionCallbackInfo<Value>& args) {
   UDPWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(
-      &wrap, args.Holder(), args.GetReturnValue().Set(UV_EBADF));
+      &wrap, args.This(), args.GetReturnValue().Set(UV_EBADF));
 
   size_t size = uv_udp_get_send_queue_size(&wrap->handle_);
   args.GetReturnValue().Set(static_cast<double>(size));
@@ -837,7 +837,7 @@ void UDPWrap::GetSendQueueSize(const FunctionCallbackInfo<Value>& args) {
 void UDPWrap::GetSendQueueCount(const FunctionCallbackInfo<Value>& args) {
   UDPWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(
-      &wrap, args.Holder(), args.GetReturnValue().Set(UV_EBADF));
+      &wrap, args.This(), args.GetReturnValue().Set(UV_EBADF));
 
   size_t count = uv_udp_get_send_queue_count(&wrap->handle_);
   args.GetReturnValue().Set(static_cast<double>(count));

--- a/test/parallel/test-timers-unref.js
+++ b/test/parallel/test-timers-unref.js
@@ -72,7 +72,7 @@ const check_unref = setInterval(() => {
     setInterval(() => timeout.unref(), SHORT_TIME);
 }
 
-// Should not assert on args.Holder()->InternalFieldCount() > 0.
+// Should not assert on args.This()->InternalFieldCount() > 0.
 // See https://github.com/nodejs/node-v0.x-archive/issues/4261.
 {
   const t = setInterval(() => {}, 1);


### PR DESCRIPTION
Namely v8::FunctionCallbackInfo::Holder(), one should use v8::FunctionCallbackInfo::This() instead.
See https://crrev.com/c/5444829 for details.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
