### PR TITLE
Update timeline-track-stacked-base.mjs DOM text reinterpreted as HTML

### DIFF
--- a/deps/v8/tools/system-analyzer/view/timeline/timeline-track-stacked-base.mjs
+++ b/deps/v8/tools/system-analyzer/view/timeline/timeline-track-stacked-base.mjs
@@ -89,7 +89,7 @@ export class TimelineTrackStackedBase extends TimelineTrackBase {
   async _drawContent() {
     if (this._originalContentWidth > 0) return;
     this._originalContentWidth = parseInt(this.timelineMarkersNode.style.width);
-    this._scalableContentNode.innerHTML = '';
+    this._scalableContentNode.innerText = '';
     let buffer = '';
     const add = async () => {
       const svg = SVG.svg();


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.