### PR TITLE
Make test-http-server-keepalive-req-gc robust to GC heuristics

### DIFF
--- a/test/parallel/test-http-server-keepalive-req-gc.js
+++ b/test/parallel/test-http-server-keepalive-req-gc.js
@@ -14,9 +14,10 @@ const server = createServer(common.mustCall((req, res) => {
   onGC(req, { ongc: common.mustCall(() => { server.close(); }) });
   req.resume();
   req.on('end', common.mustCall(() => {
-    setImmediate(() => {
+    setImmediate(async () => {
       client.end();
-      global.gc();
+      await gc({type:'major', execution:'async'});
+      await gc({type:'major', execution:'async'});
     });
   }));
   res.end('hello world');

--- a/test/parallel/test-http-server-keepalive-req-gc.js
+++ b/test/parallel/test-http-server-keepalive-req-gc.js
@@ -16,8 +16,8 @@ const server = createServer(common.mustCall((req, res) => {
   req.on('end', common.mustCall(() => {
     setImmediate(async () => {
       client.end();
-      await gc({type:'major', execution:'async'});
-      await gc({type:'major', execution:'async'});
+      await global.gc({ type: 'major', execution: 'async' });
+      await global.gc({ type: 'major', execution: 'async' });
     });
   }));
   res.end('hello world');


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This changes adds a second explicit gc call in the test. Without this call,
the test relies on gc eventually happening based, since the first call
doesn't free the object.
Relying on gc to eventually happen prevents changing GC heuristics unrelated
to this test.
The gc call is async; otherwise doing multiple sync GCs doesn't free the object.
