### PR TITLE
Don't use WrapperDescriptor and instead use Wrap/Unwrap APIs

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -65,26 +65,8 @@ inline uv_loop_t* IsolateData::event_loop() const {
 inline void IsolateData::SetCppgcReference(v8::Isolate* isolate,
                                            v8::Local<v8::Object> object,
                                            void* wrappable) {
-  v8::CppHeap* heap = isolate->GetCppHeap();
-  CHECK_NOT_NULL(heap);
-  v8::WrapperDescriptor descriptor = heap->wrapper_descriptor();
-  uint16_t required_size = std::max(descriptor.wrappable_instance_index,
-                                    descriptor.wrappable_type_index);
-  CHECK_GT(object->InternalFieldCount(), required_size);
-
-  uint16_t* id_ptr = nullptr;
-  {
-    Mutex::ScopedLock lock(isolate_data_mutex_);
-    auto it =
-        wrapper_data_map_.find(descriptor.embedder_id_for_garbage_collected);
-    CHECK_NE(it, wrapper_data_map_.end());
-    id_ptr = &(it->second->cppgc_id);
-  }
-
-  object->SetAlignedPointerInInternalField(descriptor.wrappable_type_index,
-                                           id_ptr);
-  object->SetAlignedPointerInInternalField(descriptor.wrappable_instance_index,
-                                           wrappable);
+  v8::Object::Wrap<v8::CppHeapPointerTag::kDefaultTag>(
+      isolate, object, wrappable);
 }
 
 inline uint16_t* IsolateData::embedder_id_for_cppgc() const {

--- a/src/env.cc
+++ b/src/env.cc
@@ -70,7 +70,6 @@ using v8::TryCatch;
 using v8::Uint32;
 using v8::Undefined;
 using v8::Value;
-using v8::WrapperDescriptor;
 using worker::Worker;
 
 int const ContextEmbedderTag::kNodeContextTag = 0x6e6f64;
@@ -542,30 +541,11 @@ IsolateData::IsolateData(Isolate* isolate,
 
   uint16_t cppgc_id = kDefaultCppGCEmebdderID;
   if (cpp_heap != nullptr) {
-    // The general convention of the wrappable layout for cppgc in the
-    // ecosystem is:
-    // [  0  ] -> embedder id
-    // [  1  ] -> wrappable instance
-    // If the Isolate includes a CppHeap attached by another embedder,
-    // And if they also use the field 0 for the ID, we DCHECK that
-    // the layout matches our layout, and record the embedder ID for cppgc
-    // to avoid accidentally enabling cppgc on non-cppgc-managed wrappers .
-    v8::WrapperDescriptor descriptor = cpp_heap->wrapper_descriptor();
-    if (descriptor.wrappable_type_index == BaseObject::kEmbedderType) {
-      cppgc_id = descriptor.embedder_id_for_garbage_collected;
-      DCHECK_EQ(descriptor.wrappable_instance_index, BaseObject::kSlot);
-    }
-    // If the CppHeap uses the slot we use to put non-cppgc-traced BaseObject
-    // for embedder ID, V8 could accidentally enable cppgc on them. So
-    // safe guard against this.
-    DCHECK_NE(descriptor.wrappable_type_index, BaseObject::kSlot);
+    // All CppHeap's support only one way of wrapping objects.
   } else {
     cpp_heap_ = CppHeap::Create(
         platform,
-        CppHeapCreateParams{
-            {},
-            WrapperDescriptor(
-                BaseObject::kEmbedderType, BaseObject::kSlot, cppgc_id)});
+        CppHeapCreateParams{{}});
     isolate->AttachCppHeap(cpp_heap_.get());
   }
   // We do not care about overflow since we just want this to be different

--- a/test/addons/cppgc-object/binding.cc
+++ b/test/addons/cppgc-object/binding.cc
@@ -25,11 +25,6 @@ class CppGCed : public cppgc::GarbageCollected<CppGCed> {
       v8::Local<v8::Context> context) {
     auto ft = v8::FunctionTemplate::New(context->GetIsolate(), New);
     auto ot = ft->InstanceTemplate();
-    v8::WrapperDescriptor descriptor =
-        context->GetIsolate()->GetCppHeap()->wrapper_descriptor();
-    uint16_t required_size = std::max(descriptor.wrappable_instance_index,
-                                      descriptor.wrappable_type_index);
-    ot->SetInternalFieldCount(required_size + 1);
     return ft->GetFunction(context).ToLocalChecked();
   }
 


### PR DESCRIPTION
Node has very basic support for wrapping objects and an experimental API to use `CppHeap` (Oilpan). 

This PR switches the API to using `v8::Object::Wrap()` and `v8::Object::Unwrap()` instead of using regular embedder fields. 

The PR is likely incomplete but enough to get basic tests to compile.

Also, the old apporach did distinguish between managed and unmanaged wrappers. Really, this distinction is gone as the new Wrap/Unrap APIs only support a single (the current) `CppHeap`.