### PR TITLE
Revert "[v8] Stop using deprecated fields of v8::FastApiCallbackOptions"

### DIFF
--- a/src/crypto/crypto_timing.cc
+++ b/src/crypto/crypto_timing.cc
@@ -57,8 +57,7 @@ bool FastTimingSafeEqual(Local<Value> receiver,
   uint8_t* data_b;
   if (a.length() != b.length() || !a.getStorageIfAligned(&data_a) ||
       !b.getStorageIfAligned(&data_b)) {
-    Environment* env = Environment::GetCurrent(options.isolate);
-    THROW_ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH(env);
+    options.fallback = true;
     return false;
   }
 

--- a/src/histogram.cc
+++ b/src/histogram.cc
@@ -193,8 +193,7 @@ void HistogramBase::FastRecord(Local<Value> receiver,
                                const int64_t value,
                                FastApiCallbackOptions& options) {
   if (value < 1) {
-    Environment* env = Environment::GetCurrent(options.isolate);
-    THROW_ERR_OUT_OF_RANGE(env, "value is out of range");
+    options.fallback = true;
     return;
   }
   HistogramBase* histogram;

--- a/src/node_wasi.cc
+++ b/src/node_wasi.cc
@@ -248,17 +248,17 @@ R WASI::WasiFunction<FT, F, R, Args...>::FastCallback(
   WASI* wasi = reinterpret_cast<WASI*>(BaseObject::FromJSObject(receiver));
   if (UNLIKELY(wasi == nullptr)) return EinvalError<R>();
 
-  v8::Isolate* isolate = receiver->GetIsolate();
-  if (wasi->memory_.IsEmpty()) {
-    THROW_ERR_WASI_NOT_STARTED(isolate);
-    return;
+  if (UNLIKELY(options.wasm_memory == nullptr || wasi->memory_.IsEmpty())) {
+    // fallback to slow path which to throw an error about missing memory.
+    options.fallback = true;
+    return EinvalError<R>();
   }
-  Local<ArrayBuffer> ab = wasi->memory_.Get(isolate)->Buffer();
-  size_t mem_size = ab->ByteLength();
-  char* mem_data = static_cast<char*>(ab->Data());
-  CHECK_NOT_NULL(mem_data);
+  uint8_t* memory = nullptr;
+  CHECK(LIKELY(options.wasm_memory->getStorageIfAligned(&memory)));
 
-  return F(*wasi, {mem_data, mem_size}, args...);
+  return F(*wasi,
+           {reinterpret_cast<char*>(memory), options.wasm_memory->length()},
+           args...);
 }
 
 namespace {


### PR DESCRIPTION
Reverts v8/node#192

This PR caused failing tests. Preparation is needed in V8 to allow exceptions to be thrown in fast API callbacks called from the wasm wrapper.