### PR TITLE
Remove use of deprecated type v8::FastApiTypedArray

### DIFF
--- a/src/crypto/crypto_timing.cc
+++ b/src/crypto/crypto_timing.cc
@@ -48,33 +48,11 @@ void TimingSafeEqual(const FunctionCallbackInfo<Value>& args) {
       CRYPTO_memcmp(buf1.data(), buf2.data(), buf1.size()) == 0);
 }
 
-bool FastTimingSafeEqual(Local<Value> receiver,
-                         const FastApiTypedArray<uint8_t>& a,
-                         const FastApiTypedArray<uint8_t>& b,
-                         // NOLINTNEXTLINE(runtime/references)
-                         FastApiCallbackOptions& options) {
-  uint8_t* data_a;
-  uint8_t* data_b;
-  if (a.length() != b.length() || !a.getStorageIfAligned(&data_a) ||
-      !b.getStorageIfAligned(&data_b)) {
-    Environment* env = Environment::GetCurrent(options.isolate);
-    THROW_ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH(env);
-    return false;
-  }
-
-  return CRYPTO_memcmp(data_a, data_b, a.length()) == 0;
-}
-
-static v8::CFunction fast_equal(v8::CFunction::Make(FastTimingSafeEqual));
-
 void Initialize(Environment* env, Local<Object> target) {
-  SetFastMethodNoSideEffect(
-      env->context(), target, "timingSafeEqual", TimingSafeEqual, &fast_equal);
+  SetMethod(env->context(), target, "timingSafeEqual", TimingSafeEqual);
 }
 void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(TimingSafeEqual);
-  registry->Register(FastTimingSafeEqual);
-  registry->Register(fast_equal.GetTypeInfo());
 }
 }  // namespace Timing
 

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -844,24 +844,6 @@ void Compare(const FunctionCallbackInfo<Value> &args) {
   args.GetReturnValue().Set(val);
 }
 
-int32_t FastCompare(v8::Local<v8::Value>,
-                    const FastApiTypedArray<uint8_t>& a,
-                    const FastApiTypedArray<uint8_t>& b) {
-  uint8_t* data_a;
-  uint8_t* data_b;
-  CHECK(a.getStorageIfAligned(&data_a));
-  CHECK(b.getStorageIfAligned(&data_b));
-
-  size_t cmp_length = std::min(a.length(), b.length());
-
-  return normalizeCompareVal(
-      cmp_length > 0 ? memcmp(data_a, data_b, cmp_length) : 0,
-      a.length(),
-      b.length());
-}
-
-static v8::CFunction fast_compare(v8::CFunction::Make(FastCompare));
-
 // Computes the offset for starting an indexOf or lastIndexOf search.
 // Returns either a valid offset in [0...<length - 1>], ie inside the Buffer,
 // or -1 to signal that there is no possible match.
@@ -1427,7 +1409,7 @@ void Initialize(Local<Object> target,
                             SlowByteLengthUtf8,
                             &fast_byte_length_utf8);
   SetMethod(context, target, "copy", Copy);
-  SetFastMethodNoSideEffect(context, target, "compare", Compare, &fast_compare);
+  SetMethod(context, target, "compare", Compare);
   SetMethodNoSideEffect(context, target, "compareOffset", CompareOffset);
   SetMethod(context, target, "fill", Fill);
   SetMethodNoSideEffect(context, target, "indexOfBuffer", IndexOfBuffer);
@@ -1487,8 +1469,6 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(FastByteLengthUtf8);
   registry->Register(Copy);
   registry->Register(Compare);
-  registry->Register(FastCompare);
-  registry->Register(fast_compare.GetTypeInfo());
   registry->Register(CompareOffset);
   registry->Register(Fill);
   registry->Register(IndexOfBuffer);

--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -27,15 +27,6 @@ using CFunctionCallbackWithStrings =
     bool (*)(v8::Local<v8::Value>,
              const v8::FastOneByteString& input,
              const v8::FastOneByteString& base);
-using CFunctionCallbackWithTwoUint8Arrays =
-    int32_t (*)(v8::Local<v8::Value>,
-                const v8::FastApiTypedArray<uint8_t>&,
-                const v8::FastApiTypedArray<uint8_t>&);
-using CFunctionCallbackWithTwoUint8ArraysFallback =
-    bool (*)(v8::Local<v8::Value>,
-             const v8::FastApiTypedArray<uint8_t>&,
-             const v8::FastApiTypedArray<uint8_t>&,
-             v8::FastApiCallbackOptions&);
 using CFunctionWithUint32 = uint32_t (*)(v8::Local<v8::Value>,
                                          const uint32_t input);
 using CFunctionWithDoubleReturnDouble = double (*)(v8::Local<v8::Value>,
@@ -60,8 +51,6 @@ class ExternalReferenceRegistry {
   V(CFunctionCallbackWithBool)                                                 \
   V(CFunctionCallbackWithString)                                               \
   V(CFunctionCallbackWithStrings)                                              \
-  V(CFunctionCallbackWithTwoUint8Arrays)                                       \
-  V(CFunctionCallbackWithTwoUint8ArraysFallback)                               \
   V(CFunctionWithUint32)                                                       \
   V(CFunctionWithDoubleReturnDouble)                                           \
   V(CFunctionWithInt64Fallback)                                                \


### PR DESCRIPTION
In the examples where `v8::FastApiTypedArray` was used, there is actually no advantage of using V8's fast API calls instead of regular API calls. Therefore this CL just removes the fast API call targets instead of adjusting them.