### PR TITLE
Update platform GetForegroundTaskRunner override

### DIFF
--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -558,7 +558,7 @@ bool NodePlatform::IdleTasksEnabled(Isolate* isolate) {
 
 std::shared_ptr<v8::TaskRunner>
 NodePlatform::GetForegroundTaskRunner(
-    Isolate* isolate, 
+    Isolate* isolate,
     v8::TaskPriority priority) {
   return ForIsolate(isolate)->GetForegroundTaskRunner();
 }

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -557,7 +557,9 @@ bool NodePlatform::IdleTasksEnabled(Isolate* isolate) {
 }
 
 std::shared_ptr<v8::TaskRunner>
-NodePlatform::GetForegroundTaskRunner(Isolate* isolate) {
+NodePlatform::GetForegroundTaskRunner(
+    Isolate* isolate, 
+    v8::TaskPriority priority) {
   return ForIsolate(isolate)->GetForegroundTaskRunner();
 }
 

--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -182,7 +182,7 @@ class NodePlatform : public MultiIsolatePlatform {
                                   void* data) override;
 
   std::shared_ptr<v8::TaskRunner> GetForegroundTaskRunner(
-      v8::Isolate* isolate) override;
+      v8::Isolate* isolate, v8::TaskPriority priority) override;
 
   Platform::StackTracePrinter GetStackTracePrinter() override;
   v8::PageAllocator* GetPageAllocator() override;


### PR DESCRIPTION
v8 platform is migrating to GetForegroundTaskRunner functions with priority.
https://chromium-review.googlesource.com/c/v8/v8/+/5758110

This PR updates default platform to overrides the new version of GetForegroundTaskRunner.
