### PR TITLE
Update GetForegroundTaskRunner calls

### DIFF
--- a/test/cctest/test_platform.cc
+++ b/test/cctest/test_platform.cc
@@ -24,7 +24,9 @@ class RepostingTask : public v8::Task {
     if (repost_count_ > 0) {
       --repost_count_;
       std::shared_ptr<v8::TaskRunner> task_runner =
-          platform_->GetForegroundTaskRunner(isolate_);
+          platform_->GetForegroundTaskRunner(
+            isolate_,
+            v8::TaskPriority::kUserBlocking);
       task_runner->PostTask(std::make_unique<RepostingTask>(
           repost_count_, run_count_, isolate_, platform_));
     }
@@ -46,7 +48,7 @@ TEST_F(PlatformTest, SkipNewTasksInFlushForegroundTasks) {
   Env env {handle_scope, argv};
   int run_count = 0;
   std::shared_ptr<v8::TaskRunner> task_runner =
-      platform->GetForegroundTaskRunner(isolate_);
+      platform->GetForegroundTaskRunner(isolate_, v8::TaskPriority::kUserBlocking);
   task_runner->PostTask(
       std::make_unique<RepostingTask>(2, &run_count, isolate_, platform.get()));
   EXPECT_TRUE(platform->FlushForegroundTasks(isolate_));

--- a/test/cctest/test_platform.cc
+++ b/test/cctest/test_platform.cc
@@ -25,8 +25,7 @@ class RepostingTask : public v8::Task {
       --repost_count_;
       std::shared_ptr<v8::TaskRunner> task_runner =
           platform_->GetForegroundTaskRunner(
-            isolate_,
-            v8::TaskPriority::kUserBlocking);
+              isolate_, v8::TaskPriority::kUserBlocking);
       task_runner->PostTask(std::make_unique<RepostingTask>(
           repost_count_, run_count_, isolate_, platform_));
     }
@@ -48,7 +47,8 @@ TEST_F(PlatformTest, SkipNewTasksInFlushForegroundTasks) {
   Env env {handle_scope, argv};
   int run_count = 0;
   std::shared_ptr<v8::TaskRunner> task_runner =
-      platform->GetForegroundTaskRunner(isolate_, v8::TaskPriority::kUserBlocking);
+      platform->GetForegroundTaskRunner(
+          isolate_, v8::TaskPriority::kUserBlocking);
   task_runner->PostTask(
       std::make_unique<RepostingTask>(2, &run_count, isolate_, platform.get()));
   EXPECT_TRUE(platform->FlushForegroundTasks(isolate_));


### PR DESCRIPTION
Follow-up on https://github.com/v8/node/pull/198
This updates calls to NodePlatform, which now need to explicitly pass priority argument
to GetForegroundTaskRunner().