### PR TITLE
[fastapi] Stop using deprecated FastApiTypedArray

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -594,6 +594,7 @@ uint32_t FastCopy(Local<Value> receiver,
                   uint32_t target_start,
                   uint32_t source_start,
                   uint32_t to_copy,
+                  // NOLINTNEXTLINE(runtime/references) This is V8 api.
                   v8::FastApiCallbackOptions& options) {
   ArrayBufferViewContents<char> source(source_obj);
   SPREAD_BUFFER_ARG(target_obj, target);
@@ -1477,6 +1478,7 @@ uint32_t FastWriteString(Local<Value> receiver,
                          const v8::FastOneByteString& src,
                          uint32_t offset,
                          uint32_t max_length,
+                         // NOLINTNEXTLINE(runtime/references) This is V8 api.
                          v8::FastApiCallbackOptions& options) {
   THROW_AND_RETURN_VAL_UNLESS_BUFFER(options.isolate, dst, "dst", 0);
   SPREAD_BUFFER_ARG(dst, dst_buffer);

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -42,7 +42,15 @@
 #include "nbytes.h"
 
 #define THROW_AND_RETURN_UNLESS_BUFFER(env, obj)                            \
-  THROW_AND_RETURN_IF_NOT_BUFFER(env, obj, "argument")                      \
+  THROW_AND_RETURN_IF_NOT_BUFFER(env, obj, "argument")
+
+#define THROW_AND_RETURN_VAL_UNLESS_BUFFER(isolate, val, prefix, retval)       \
+  do {                                                                         \
+    if (!Buffer::HasInstance(val)) {                                           \
+      node::THROW_ERR_INVALID_ARG_TYPE(isolate, prefix " must be a buffer");   \
+      return retval;                                                           \
+    }                                                                          \
+  } while (0)
 
 #define THROW_AND_RETURN_IF_OOB(r)                                          \
   do {                                                                      \
@@ -60,7 +68,6 @@ using v8::ArrayBufferView;
 using v8::BackingStore;
 using v8::Context;
 using v8::EscapableHandleScope;
-using v8::FastApiTypedArray;
 using v8::FunctionCallbackInfo;
 using v8::Global;
 using v8::HandleScope;
@@ -582,19 +589,16 @@ void SlowCopy(const FunctionCallbackInfo<Value>& args) {
 
 // Assume caller has properly validated args.
 uint32_t FastCopy(Local<Value> receiver,
-                  const v8::FastApiTypedArray<uint8_t>& source,
-                  const v8::FastApiTypedArray<uint8_t>& target,
+                  Local<Value> source_obj,
+                  Local<Value> target_obj,
                   uint32_t target_start,
                   uint32_t source_start,
-                  uint32_t to_copy) {
-  uint8_t* source_data;
-  CHECK(source.getStorageIfAligned(&source_data));
+                  uint32_t to_copy,
+                  v8::FastApiCallbackOptions& options) {
+  ArrayBufferViewContents<char> source(source_obj);
+  SPREAD_BUFFER_ARG(target_obj, target);
 
-  uint8_t* target_data;
-  CHECK(target.getStorageIfAligned(&target_data));
-
-  memmove(target_data + target_start, source_data + source_start, to_copy);
-
+  memmove(target_data + target_start, source.data() + source_start, to_copy);
   return to_copy;
 }
 
@@ -1469,21 +1473,24 @@ void SlowWriteString(const FunctionCallbackInfo<Value>& args) {
 
 template <encoding encoding>
 uint32_t FastWriteString(Local<Value> receiver,
-                         const v8::FastApiTypedArray<uint8_t>& dst,
+                         Local<Value> dst,
                          const v8::FastOneByteString& src,
                          uint32_t offset,
-                         uint32_t max_length) {
-  uint8_t* dst_data;
-  CHECK(dst.getStorageIfAligned(&dst_data));
-  CHECK(offset <= dst.length());
-  CHECK(dst.length() - offset <= std::numeric_limits<uint32_t>::max());
+                         uint32_t max_length,
+                         v8::FastApiCallbackOptions& options) {
+  THROW_AND_RETURN_VAL_UNLESS_BUFFER(options.isolate, dst, "dst", 0);
+  SPREAD_BUFFER_ARG(dst, dst_buffer);
+  CHECK(dst_buffer_length <=
+        static_cast<size_t>(std::numeric_limits<uint32_t>::max()));
+  uint32_t dst_size = static_cast<uint32_t>(dst_buffer_length);
+  CHECK(offset <= dst_size);
   TRACK_V8_FAST_API_CALL("buffer.writeString");
 
   return WriteOneByteString<encoding>(
       src.data,
       src.length,
-      reinterpret_cast<char*>(dst_data + offset),
-      std::min<uint32_t>(dst.length() - offset, max_length));
+      reinterpret_cast<char*>(dst_buffer_data + offset),
+      std::min<uint32_t>(dst_size - offset, max_length));
 }
 
 static v8::CFunction fast_write_string_ascii(

--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -53,18 +53,20 @@ using CFunctionWithBool = void (*)(v8::Local<v8::Value>,
 
 using CFunctionWriteString =
     uint32_t (*)(v8::Local<v8::Value> receiver,
-                 const v8::FastApiTypedArray<uint8_t>& dst,
+                 v8::Local<v8::Value> dst,
                  const v8::FastOneByteString& src,
                  uint32_t offset,
-                 uint32_t max_length);
+                 uint32_t max_length,
+                 v8::FastApiCallbackOptions&);
 
 using CFunctionBufferCopy =
     uint32_t (*)(v8::Local<v8::Value> receiver,
-                 const v8::FastApiTypedArray<uint8_t>& source,
-                 const v8::FastApiTypedArray<uint8_t>& target,
+                 v8::Local<v8::Value> source,
+                 v8::Local<v8::Value> target,
                  uint32_t target_start,
                  uint32_t source_start,
-                 uint32_t to_copy);
+                 uint32_t to_copy,
+                 v8::FastApiCallbackOptions&);
 
 // This class manages the external references from the V8 heap
 // to the C++ addresses in Node.js.


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
