### PR TITLE
Temporarily skip tests that expect Function.blah in stack taces

### DIFF
--- a/test/message/message.status
+++ b/test/message/message.status
@@ -33,6 +33,10 @@ vm_display_syntax_error.js: SKIP
 vm_dont_display_runtime_error.js: SKIP
 vm_dont_display_syntax_error.js: SKIP
 
+# Temporarily skip for https://crrev.com/c/5907815
+assert_throws_stack.js: SKIP
+internal_assert_fail.js: SKIP
+
 [$system==win32]
 
 [$system==linux]

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -70,6 +70,9 @@ test-v8-serdes: SKIP
 
 test-v8-stats: SKIP
 
+# Temporarily skip for https://crrev.com/c/5907815
+test-fs-promises: SKIP
+
 test-strace-openat-openssl: SKIP
 test-policy-dependency-conditions: SKIP
 


### PR DESCRIPTION
These tests will be re-enabled once a V8 CL https://crrev.com/c/5907815 lands. The CL changes the way such entries are displayed in stack traces to Constructor.blah.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
