### PR TITLE
Update tests expectations that check stack traces.

### DIFF
--- a/test/message/assert_throws_stack.out
+++ b/test/message/assert_throws_stack.out
@@ -23,7 +23,7 @@ AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
   actual: Error: foo
       at assert.throws.bar (*assert_throws_stack.js:*)
       at getActual (node:assert:*)
-      at Function.throws (node:assert:*)
+      at strict.throws (node:assert:*)
       at Object.<anonymous> (*assert_throws_stack.js:*:*)
       at *
       at *

--- a/test/message/internal_assert_fail.out
+++ b/test/message/internal_assert_fail.out
@@ -6,7 +6,7 @@ Error [ERR_INTERNAL_ASSERTION]: Unreachable!
 This is caused by either a bug in Node.js or incorrect usage of Node.js internals.
 Please open an issue with this stack trace at https://github.com/nodejs/node/issues
 
-    at Function.fail (node:internal/assert:*:*)
+    at assert.fail (node:internal/assert:*:*)
     at * (*test*message*internal_assert_fail.js:7:8)
     at *
     at *

--- a/test/message/message.status
+++ b/test/message/message.status
@@ -33,10 +33,6 @@ vm_display_syntax_error.js: SKIP
 vm_dont_display_runtime_error.js: SKIP
 vm_dont_display_syntax_error.js: SKIP
 
-# Temporarily skip for https://crrev.com/c/5907815
-assert_throws_stack.js: SKIP
-internal_assert_fail.js: SKIP
-
 [$system==win32]
 
 [$system==linux]

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -70,9 +70,6 @@ test-v8-serdes: SKIP
 
 test-v8-stats: SKIP
 
-# Temporarily skip for https://crrev.com/c/5907815
-test-fs-promises: SKIP
-
 test-strace-openat-openssl: SKIP
 test-policy-dependency-conditions: SKIP
 

--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -58,7 +58,7 @@ assert.strictEqual(
       code: 'ENOENT',
       name: 'Error',
       message: /^ENOENT: no such file or directory, access/,
-      stack: /at async Function\.rejects/
+      stack: /at async ok\.rejects/
     }
   ).then(common.mustCall());
 


### PR DESCRIPTION
V8 has changed how Function.blah entries look like in stack traces (see https://crrev.com/c/5907815). This CL updates tests expectations according to new behavior and re-enables the affected tests.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
