### PR TITLE
Update parallel.status to unblock shipment of Explicit resource management

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -68,6 +68,10 @@ test-util-inspect: SKIP
 # Skip a test which prevents updating the ValueSerialiser format
 test-v8-serdes: SKIP
 
+# Skip failed test to ship explicit resource management
+# https://crrev.com/c/6072348
+test-vm-global-property-enumerator: SKIP
+
 test-v8-stats: SKIP
 
 test-strace-openat-openssl: SKIP


### PR DESCRIPTION
Explicit resource management proposal adds three new global objects `SuppressedError`, `DisposableStack` and `AsyncDisposableStack`. Since they are not listed in globals.intrinsics, this test is failing. 
