### PR TITLE
[test] Pass existing CppHeap to Isolate creation

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -351,9 +351,13 @@ Isolate* NewIsolate(ArrayBufferAllocator* allocator,
                     uv_loop_t* event_loop,
                     MultiIsolatePlatform* platform,
                     const EmbedderSnapshotData* snapshot_data,
-                    const IsolateSettings& settings) {
+                    const IsolateSettings& settings,
+                    std::unique_ptr<v8::CppHeap> cpp_heap) {
   Isolate::CreateParams params;
   if (allocator != nullptr) params.array_buffer_allocator = allocator;
+  if (cpp_heap) {
+    params.cpp_heap = cpp_heap.release();
+  }
   return NewIsolate(&params,
                     event_loop,
                     platform,

--- a/src/node.h
+++ b/src/node.h
@@ -578,7 +578,8 @@ NODE_EXTERN v8::Isolate* NewIsolate(
     struct uv_loop_s* event_loop,
     MultiIsolatePlatform* platform,
     const EmbedderSnapshotData* snapshot_data = nullptr,
-    const IsolateSettings& settings = {});
+    const IsolateSettings& settings = {},
+    std::unique_ptr<v8::CppHeap> cpp_heap = {});
 NODE_EXTERN v8::Isolate* NewIsolate(
     std::shared_ptr<ArrayBufferAllocator> allocator,
     struct uv_loop_s* event_loop,

--- a/test/cctest/test_cppgc.cc
+++ b/test/cctest/test_cppgc.cc
@@ -46,18 +46,14 @@ int CppGCed::kDestructCount = 0;
 int CppGCed::kTraceCount = 0;
 
 TEST_F(NodeZeroIsolateTestFixture, ExistingCppHeapTest) {
-  v8::Isolate* isolate =
-      node::NewIsolate(allocator.get(), &current_loop, platform.get());
-
   // Create and attach the CppHeap before we set up the IsolateData so that
   // it recognizes the existing heap.
   std::unique_ptr<v8::CppHeap> cpp_heap =
       v8::CppHeap::Create(platform.get(), v8::CppHeapCreateParams{{}});
 
-  // TODO(joyeecheung): pass it into v8::Isolate::CreateParams and let V8
-  // own it when we can keep the isolate registered/task runner discoverable
-  // during isolate disposal.
-  isolate->AttachCppHeap(cpp_heap.get());
+  v8::Isolate* isolate =
+      node::NewIsolate(allocator.get(), &current_loop, platform.get(),
+      nullptr, {}, std::move(cpp_heap));
 
   // Try creating Context + IsolateData + Environment.
   {
@@ -102,8 +98,6 @@ TEST_F(NodeZeroIsolateTestFixture, ExistingCppHeapTest) {
     platform->DrainTasks(isolate);
 
     // Cleanup.
-    isolate->DetachCppHeap();
-    cpp_heap->Terminate();
     platform->DrainTasks(isolate);
   }
 


### PR DESCRIPTION
New V8 API expects a CppHeap to exist for the whole existence of an Isolate. Therefore the APIs for attaching and detaching a CppHeap get deprecated, and an existing CppHeap has to be passed to the isolate during isolate creation. This PR adjusts a test that passes an existing CppHeap too late to the isolate.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
