### PR TITLE
[json_parser] Add missing isolate scope

### DIFF
--- a/src/json_parser.cc
+++ b/src/json_parser.cc
@@ -105,6 +105,7 @@ std::optional<bool> JSONParser::GetTopLevelBoolField(std::string_view field) {
 std::optional<JSONParser::StringDict> JSONParser::GetTopLevelStringDict(
     std::string_view field) {
   Isolate* isolate = isolate_.get();
+  v8::Isolate::Scope isolate_scope(isolate);
   v8::HandleScope handle_scope(isolate);
   Local<Context> context = context_.Get(isolate);
   Local<Object> content_object = content_.Get(isolate);


### PR DESCRIPTION
Other methods in the same file already had it, but in this one spot it was missing. This blocked https://crrev.com/c/6458560.
