### PR TITLE
Replace `GetIsolate()` by `Isolate::GetCurrent()`

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -636,7 +636,7 @@ std::unique_ptr<MultiIsolatePlatform> MultiIsolatePlatform::Create(
 
 MaybeLocal<Object> GetPerContextExports(Local<Context> context,
                                         IsolateData* isolate_data) {
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   EscapableHandleScope handle_scope(isolate);
 
   Local<Object> global = context->Global();
@@ -682,7 +682,7 @@ void ProtoThrower(const FunctionCallbackInfo<Value>& info) {
 // This runs at runtime, regardless of whether the context
 // is created from a snapshot.
 Maybe<void> InitializeContextRuntime(Local<Context> context) {
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   HandleScope handle_scope(isolate);
 
   // When `IsCodeGenerationFromStringsAllowed` is true, V8 takes the fast path
@@ -761,7 +761,7 @@ Maybe<void> InitializeContextRuntime(Local<Context> context) {
 }
 
 Maybe<void> InitializeBaseContextForSnapshot(Local<Context> context) {
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   HandleScope handle_scope(isolate);
 
   // Delete `Intl.v8BreakIterator`
@@ -786,7 +786,7 @@ Maybe<void> InitializeBaseContextForSnapshot(Local<Context> context) {
 }
 
 Maybe<void> InitializeMainContextForSnapshot(Local<Context> context) {
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   HandleScope handle_scope(isolate);
 
   // Initialize the default values.
@@ -804,7 +804,7 @@ Maybe<void> InitializeMainContextForSnapshot(Local<Context> context) {
 MaybeLocal<Object> InitializePrivateSymbols(Local<Context> context,
                                             IsolateData* isolate_data) {
   CHECK(isolate_data);
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   EscapableHandleScope scope(isolate);
   Context::Scope context_scope(context);
 
@@ -828,7 +828,7 @@ MaybeLocal<Object> InitializePrivateSymbols(Local<Context> context,
 MaybeLocal<Object> InitializePerIsolateSymbols(Local<Context> context,
                                                IsolateData* isolate_data) {
   CHECK(isolate_data);
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   EscapableHandleScope scope(isolate);
   Context::Scope context_scope(context);
 
@@ -854,7 +854,7 @@ MaybeLocal<Object> InitializePerIsolateSymbols(Local<Context> context,
 Maybe<void> InitializePrimordials(Local<Context> context,
                                   IsolateData* isolate_data) {
   // Run per-context JS files.
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   Context::Scope context_scope(context);
   Local<Object> exports;
 

--- a/src/crypto/crypto_context.cc
+++ b/src/crypto/crypto_context.cc
@@ -948,7 +948,7 @@ bool ArrayOfStringsToX509s(Local<Context> context,
                            Local<Array> cert_array,
                            std::vector<X509*>* certs) {
   ClearErrorOnReturn clear_error_on_return;
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   Environment* env = Environment::GetCurrent(context);
   uint32_t array_length = cert_array->Length();
 

--- a/src/crypto/crypto_x509.cc
+++ b/src/crypto/crypto_x509.cc
@@ -105,7 +105,7 @@ MaybeLocal<Value> ToV8Value(Local<Context> context, BIOPointer&& bio) {
     return {};
   BUF_MEM* mem = bio;
   Local<Value> ret;
-  if (!String::NewFromUtf8(context->GetIsolate(),
+  if (!String::NewFromUtf8(Isolate::GetCurrent(),
                            mem->data,
                            NewStringType::kNormal,
                            mem->length)
@@ -119,7 +119,7 @@ MaybeLocal<Value> ToV8Value(Local<Context> context, const BIOPointer& bio) {
     return {};
   BUF_MEM* mem = bio;
   Local<Value> ret;
-  if (!String::NewFromUtf8(context->GetIsolate(),
+  if (!String::NewFromUtf8(Isolate::GetCurrent(),
                            mem->data,
                            NewStringType::kNormal,
                            mem->length)

--- a/src/encoding_binding.cc
+++ b/src/encoding_binding.cc
@@ -76,7 +76,7 @@ void BindingData::Deserialize(Local<Context> context,
                               int index,
                               InternalFieldInfoBase* info) {
   DCHECK_IS_SNAPSHOT_SLOT(index);
-  HandleScope scope(context->GetIsolate());
+  HandleScope scope(Isolate::GetCurrent());
   Realm* realm = Realm::GetCurrent(context);
   // Recreate the buffer in the constructor.
   InternalFieldInfo* casted_info = static_cast<InternalFieldInfo*>(info);

--- a/src/env.cc
+++ b/src/env.cc
@@ -1750,10 +1750,10 @@ void AsyncHooks::Deserialize(Local<Context> context) {
         context->GetDataFromSnapshotOnce<Array>(
             info_->js_execution_async_resources).ToLocalChecked();
   } else {
-    js_execution_async_resources = Array::New(context->GetIsolate());
+    js_execution_async_resources = Array::New(Isolate::GetCurrent());
   }
   js_execution_async_resources_.Reset(
-      context->GetIsolate(), js_execution_async_resources);
+      Isolate::GetCurrent(), js_execution_async_resources);
 
   // The native_execution_async_resources_ field requires v8::Local<> instances
   // for async calls whose resources were on the stack as JS objects when they
@@ -1793,7 +1793,7 @@ AsyncHooks::SerializeInfo AsyncHooks::Serialize(Local<Context> context,
   info.async_id_fields = async_id_fields_.Serialize(context, creator);
   if (!js_execution_async_resources_.IsEmpty()) {
     info.js_execution_async_resources = creator->AddData(
-        context, js_execution_async_resources_.Get(context->GetIsolate()));
+        context, js_execution_async_resources_.Get(Isolate::GetCurrent()));
     CHECK_NE(info.js_execution_async_resources, 0);
   } else {
     info.js_execution_async_resources = 0;

--- a/src/inspector/network_agent.cc
+++ b/src/inspector/network_agent.cc
@@ -29,31 +29,31 @@ using v8::Value;
 Maybe<protocol::String> ObjectGetProtocolString(v8::Local<v8::Context> context,
                                                 Local<Object> object,
                                                 Local<v8::String> property) {
-  HandleScope handle_scope(context->GetIsolate());
+  HandleScope handle_scope(v8::Isolate::GetCurrent());
   Local<Value> value;
   if (!object->Get(context, property).ToLocal(&value) || !value->IsString()) {
     return Nothing<protocol::String>();
   }
   Local<v8::String> str = value.As<v8::String>();
-  return Just(ToProtocolString(context->GetIsolate(), str));
+  return Just(ToProtocolString(v8::Isolate::GetCurrent(), str));
 }
 
 // Get a protocol string property from the object.
 Maybe<protocol::String> ObjectGetProtocolString(v8::Local<v8::Context> context,
                                                 Local<Object> object,
                                                 const char* property) {
-  HandleScope handle_scope(context->GetIsolate());
+  HandleScope handle_scope(v8::Isolate::GetCurrent());
   return ObjectGetProtocolString(
-      context, object, OneByteString(context->GetIsolate(), property));
+      context, object, OneByteString(v8::Isolate::GetCurrent(), property));
 }
 
 // Get a protocol double property from the object.
 Maybe<double> ObjectGetDouble(v8::Local<v8::Context> context,
                               Local<Object> object,
                               const char* property) {
-  HandleScope handle_scope(context->GetIsolate());
+  HandleScope handle_scope(v8::Isolate::GetCurrent());
   Local<Value> value;
-  if (!object->Get(context, OneByteString(context->GetIsolate(), property))
+  if (!object->Get(context, OneByteString(v8::Isolate::GetCurrent(), property))
            .ToLocal(&value) ||
       !value->IsNumber()) {
     return Nothing<double>();
@@ -65,9 +65,9 @@ Maybe<double> ObjectGetDouble(v8::Local<v8::Context> context,
 Maybe<int> ObjectGetInt(v8::Local<v8::Context> context,
                         Local<Object> object,
                         const char* property) {
-  HandleScope handle_scope(context->GetIsolate());
+  HandleScope handle_scope(v8::Isolate::GetCurrent());
   Local<Value> value;
-  if (!object->Get(context, OneByteString(context->GetIsolate(), property))
+  if (!object->Get(context, OneByteString(v8::Isolate::GetCurrent(), property))
            .ToLocal(&value) ||
       !value->IsInt32()) {
     return Nothing<int>();
@@ -79,9 +79,9 @@ Maybe<int> ObjectGetInt(v8::Local<v8::Context> context,
 Maybe<bool> ObjectGetBool(v8::Local<v8::Context> context,
                           Local<Object> object,
                           const char* property) {
-  HandleScope handle_scope(context->GetIsolate());
+  HandleScope handle_scope(v8::Isolate::GetCurrent());
   Local<Value> value;
-  if (!object->Get(context, OneByteString(context->GetIsolate(), property))
+  if (!object->Get(context, OneByteString(v8::Isolate::GetCurrent(), property))
            .ToLocal(&value) ||
       !value->IsBoolean()) {
     return Nothing<bool>();
@@ -93,9 +93,9 @@ Maybe<bool> ObjectGetBool(v8::Local<v8::Context> context,
 MaybeLocal<v8::Object> ObjectGetObject(v8::Local<v8::Context> context,
                                        Local<Object> object,
                                        const char* property) {
-  EscapableHandleScope handle_scope(context->GetIsolate());
+  EscapableHandleScope handle_scope(v8::Isolate::GetCurrent());
   Local<Value> value;
-  if (!object->Get(context, OneByteString(context->GetIsolate(), property))
+  if (!object->Get(context, OneByteString(v8::Isolate::GetCurrent(), property))
            .ToLocal(&value) ||
       !value->IsObject()) {
     return {};
@@ -106,7 +106,7 @@ MaybeLocal<v8::Object> ObjectGetObject(v8::Local<v8::Context> context,
 // Create a protocol::Network::Headers from the v8 object.
 std::unique_ptr<protocol::Network::Headers> createHeadersFromObject(
     v8::Local<v8::Context> context, Local<Object> headers_obj) {
-  HandleScope handle_scope(context->GetIsolate());
+  HandleScope handle_scope(v8::Isolate::GetCurrent());
 
   std::unique_ptr<protocol::DictionaryValue> dict =
       protocol::DictionaryValue::create();
@@ -127,7 +127,7 @@ std::unique_ptr<protocol::Network::Headers> createHeadersFromObject(
              .To(&property_value)) {
       return {};
     }
-    dict->setString(ToProtocolString(context->GetIsolate(), property_name),
+    dict->setString(ToProtocolString(v8::Isolate::GetCurrent(), property_name),
                     property_value);
   }
 
@@ -137,7 +137,7 @@ std::unique_ptr<protocol::Network::Headers> createHeadersFromObject(
 // Create a protocol::Network::Request from the v8 object.
 std::unique_ptr<protocol::Network::Request> createRequestFromObject(
     v8::Local<v8::Context> context, Local<Object> request) {
-  HandleScope handle_scope(context->GetIsolate());
+  HandleScope handle_scope(v8::Isolate::GetCurrent());
   protocol::String url;
   if (!ObjectGetProtocolString(context, request, "url").To(&url)) {
     return {};
@@ -169,7 +169,7 @@ std::unique_ptr<protocol::Network::Request> createRequestFromObject(
 // Create a protocol::Network::Response from the v8 object.
 std::unique_ptr<protocol::Network::Response> createResponseFromObject(
     v8::Local<v8::Context> context, Local<Object> response) {
-  HandleScope handle_scope(context->GetIsolate());
+  HandleScope handle_scope(v8::Isolate::GetCurrent());
   protocol::String url;
   if (!ObjectGetProtocolString(context, response, "url").To(&url)) {
     return {};
@@ -210,7 +210,7 @@ std::unique_ptr<protocol::Network::Response> createResponseFromObject(
 
 std::unique_ptr<protocol::Network::WebSocketResponse> createWebSocketResponse(
     v8::Local<v8::Context> context, Local<Object> response) {
-  HandleScope handle_scope(context->GetIsolate());
+  HandleScope handle_scope(v8::Isolate::GetCurrent());
   int status;
   if (!ObjectGetInt(context, response, "status").To(&status)) {
     return {};

--- a/src/js_native_api_v8.h
+++ b/src/js_native_api_v8.h
@@ -53,7 +53,7 @@ class RefTracker {
 struct napi_env__ {
   explicit napi_env__(v8::Local<v8::Context> context,
                       int32_t module_api_version)
-      : isolate(context->GetIsolate()),
+      : isolate(v8::Isolate::GetCurrent()),
         context_persistent(isolate, context),
         module_api_version(module_api_version) {
     napi_clear_last_error(this);

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -77,7 +77,7 @@ ModuleCacheKey ModuleCacheKey::From(Local<Context> context,
                                     Local<String> specifier,
                                     Local<FixedArray> import_attributes) {
   CHECK_EQ(import_attributes->Length() % elements_per_attribute, 0);
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   std::size_t h1 = specifier->GetIdentityHash();
   size_t num_attributes = import_attributes->Length() / elements_per_attribute;
   ImportAttributeVector attributes;
@@ -1000,7 +1000,7 @@ MaybeLocal<Module> ModuleWrap::ResolveModuleCallback(
     return {};
   }
   DCHECK_NOT_NULL(resolved_module);
-  return resolved_module->module_.Get(context->GetIsolate());
+  return resolved_module->module_.Get(Isolate::GetCurrent());
 }
 
 // static
@@ -1024,7 +1024,7 @@ MaybeLocal<Object> ModuleWrap::ResolveSourceCallback(
     Local<String> url = resolved_module->object()
                             ->GetInternalField(ModuleWrap::kURLSlot)
                             .As<String>();
-    THROW_ERR_SOURCE_PHASE_NOT_DEFINED(context->GetIsolate(), url);
+    THROW_ERR_SOURCE_PHASE_NOT_DEFINED(Isolate::GetCurrent(), url);
     return {};
   }
   CHECK(module_source_object->IsObject());
@@ -1037,7 +1037,7 @@ Maybe<ModuleWrap*> ModuleWrap::ResolveModule(
     Local<String> specifier,
     Local<FixedArray> import_attributes,
     Local<Module> referrer) {
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   Environment* env = Environment::GetCurrent(context);
   if (env == nullptr) {
     THROW_ERR_EXECUTION_ENVIRONMENT_NOT_AVAILABLE(isolate);
@@ -1082,7 +1082,7 @@ static MaybeLocal<Promise> ImportModuleDynamicallyWithPhase(
     Local<String> specifier,
     ModuleImportPhase phase,
     Local<FixedArray> import_attributes) {
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   Environment* env = Environment::GetCurrent(context);
   if (env == nullptr) {
     THROW_ERR_EXECUTION_ENVIRONMENT_NOT_AVAILABLE(isolate);
@@ -1321,7 +1321,7 @@ MaybeLocal<Module> LinkRequireFacadeWithOriginal(
     Local<FixedArray> import_attributes,
     Local<Module> referrer) {
   Environment* env = Environment::GetCurrent(context);
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   CHECK(specifier->Equals(context, env->original_string()).ToChecked());
   CHECK(!env->temporary_required_module_facade_original.IsEmpty());
   return env->temporary_required_module_facade_original.Get(isolate);

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -178,7 +178,7 @@ ModuleWrap* ModuleWrap::GetLinkedRequest(uint32_t index) {
       object()->GetInternalField(kLinkedRequestsSlot);
   DCHECK(linked_requests_data->IsValue() &&
          linked_requests_data.As<Value>()->IsArray());
-  Local<Array> requests = linked_requests_data.As<Array>();
+  Local<Array> requests = linked_requests_data.As<Value>().As<Array>();
 
   CHECK_LT(index, requests->Length());
 

--- a/src/node.h
+++ b/src/node.h
@@ -1001,20 +1001,20 @@ NODE_DEPRECATED("Use v8::Date::ValueOf() directly",
 #define NODE_V8_UNIXTIME node::NODE_V8_UNIXTIME
 
 #define NODE_DEFINE_CONSTANT(target, constant)                                 \
-do {                                                                         \
-v8::Isolate* isolate = v8::Isolate::GetCurrent();                          \
-v8::Local<v8::Context> context = isolate->GetCurrentContext();             \
-v8::Local<v8::String> constant_name = v8::String::NewFromUtf8Literal(      \
-isolate, #constant, v8::NewStringType::kInternalized);                 \
-v8::Local<v8::Number> constant_value =                                     \
-v8::Number::New(isolate, static_cast<double>(constant));               \
-v8::PropertyAttribute constant_attributes =                                \
-static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete);     \
-(target)                                                                   \
-->DefineOwnProperty(                                                   \
-context, constant_name, constant_value, constant_attributes)       \
-.Check();                                                              \
-} while (0)
+  do {                                                                         \
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();                          \
+    v8::Local<v8::Context> context = isolate->GetCurrentContext();             \
+    v8::Local<v8::String> constant_name = v8::String::NewFromUtf8Literal(      \
+        isolate, #constant, v8::NewStringType::kInternalized);                 \
+    v8::Local<v8::Number> constant_value =                                     \
+        v8::Number::New(isolate, static_cast<double>(constant));               \
+    v8::PropertyAttribute constant_attributes =                                \
+        static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete);     \
+    (target)                                                                   \
+        ->DefineOwnProperty(                                                   \
+            context, constant_name, constant_value, constant_attributes)       \
+        .Check();                                                              \
+  } while (0)
 
 #define NODE_DEFINE_HIDDEN_CONSTANT(target, constant)                          \
   do {                                                                         \

--- a/src/node.h
+++ b/src/node.h
@@ -1001,24 +1001,24 @@ NODE_DEPRECATED("Use v8::Date::ValueOf() directly",
 #define NODE_V8_UNIXTIME node::NODE_V8_UNIXTIME
 
 #define NODE_DEFINE_CONSTANT(target, constant)                                 \
-  do {                                                                         \
-    v8::Isolate* isolate = target->GetIsolate();                               \
-    v8::Local<v8::Context> context = isolate->GetCurrentContext();             \
-    v8::Local<v8::String> constant_name = v8::String::NewFromUtf8Literal(      \
-        isolate, #constant, v8::NewStringType::kInternalized);                 \
-    v8::Local<v8::Number> constant_value =                                     \
-        v8::Number::New(isolate, static_cast<double>(constant));               \
-    v8::PropertyAttribute constant_attributes =                                \
-        static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete);     \
-    (target)                                                                   \
-        ->DefineOwnProperty(                                                   \
-            context, constant_name, constant_value, constant_attributes)       \
-        .Check();                                                              \
-  } while (0)
+do {                                                                         \
+v8::Isolate* isolate = v8::Isolate::GetCurrent();                          \
+v8::Local<v8::Context> context = isolate->GetCurrentContext();             \
+v8::Local<v8::String> constant_name = v8::String::NewFromUtf8Literal(      \
+isolate, #constant, v8::NewStringType::kInternalized);                 \
+v8::Local<v8::Number> constant_value =                                     \
+v8::Number::New(isolate, static_cast<double>(constant));               \
+v8::PropertyAttribute constant_attributes =                                \
+static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete);     \
+(target)                                                                   \
+->DefineOwnProperty(                                                   \
+context, constant_name, constant_value, constant_attributes)       \
+.Check();                                                              \
+} while (0)
 
 #define NODE_DEFINE_HIDDEN_CONSTANT(target, constant)                          \
   do {                                                                         \
-    v8::Isolate* isolate = target->GetIsolate();                               \
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();                          \
     v8::Local<v8::Context> context = isolate->GetCurrentContext();             \
     v8::Local<v8::String> constant_name = v8::String::NewFromUtf8Literal(      \
         isolate, #constant, v8::NewStringType::kInternalized);                 \

--- a/src/node_blob.cc
+++ b/src/node_blob.cc
@@ -557,7 +557,7 @@ void BlobBindingData::Deserialize(Local<Context> context,
                                   int index,
                                   InternalFieldInfoBase* info) {
   DCHECK_IS_SNAPSHOT_SLOT(index);
-  HandleScope scope(context->GetIsolate());
+  HandleScope scope(Isolate::GetCurrent());
   Realm* realm = Realm::GetCurrent(context);
   BlobBindingData* binding = realm->AddBindingData<BlobBindingData>(holder);
   CHECK_NOT_NULL(binding);

--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -274,7 +274,7 @@ MaybeLocal<Function> BuiltinLoader::LookupAndCompileInternal(
     const char* id,
     LocalVector<String>* parameters,
     Realm* optional_realm) {
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   EscapableHandleScope scope(isolate);
 
   Local<String> source;
@@ -396,7 +396,7 @@ void BuiltinLoader::SaveCodeCache(const char* id, Local<Function> fun) {
 MaybeLocal<Function> BuiltinLoader::LookupAndCompile(Local<Context> context,
                                                      const char* id,
                                                      Realm* optional_realm) {
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   LocalVector<String> parameters(isolate);
   // Detects parameters of the scripts based on module ids.
   // internal/bootstrap/realm: process, getLinkedBinding,
@@ -450,7 +450,7 @@ MaybeLocal<Function> BuiltinLoader::LookupAndCompile(Local<Context> context,
 MaybeLocal<Value> BuiltinLoader::CompileAndCall(Local<Context> context,
                                                 const char* id,
                                                 Realm* realm) {
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   // Detects parameters of the scripts based on module ids.
   // internal/bootstrap/realm: process, getLinkedBinding,
   //                           getInternalBinding, primordials
@@ -506,7 +506,7 @@ MaybeLocal<Value> BuiltinLoader::CompileAndCall(Local<Context> context,
   if (!maybe_fn.ToLocal(&fn)) {
     return MaybeLocal<Value>();
   }
-  Local<Value> undefined = Undefined(context->GetIsolate());
+  Local<Value> undefined = Undefined(Isolate::GetCurrent());
   return fn->Call(context, undefined, argc, argv);
 }
 
@@ -544,14 +544,14 @@ bool BuiltinLoader::CompileAllBuiltinsAndCopyCodeCache(
       to_eager_compile_.emplace(id);
     }
 
-    TryCatch bootstrapCatch(context->GetIsolate());
+    TryCatch bootstrapCatch(Isolate::GetCurrent());
     auto fn = LookupAndCompile(context, id.data(), nullptr);
     if (bootstrapCatch.HasCaught()) {
       per_process::Debug(DebugCategory::CODE_CACHE,
                          "Failed to compile code cache for %s\n",
                          id.data());
       all_succeeded = false;
-      PrintCaughtException(context->GetIsolate(), context, bootstrapCatch);
+      PrintCaughtException(Isolate::GetCurrent(), context, bootstrapCatch);
     } else {
       // This is used by the snapshot builder, so save the code cache
       // unconditionally.

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -1281,7 +1281,7 @@ void CreatePerContextProperties(Local<Object> target,
                                 Local<Value> unused,
                                 Local<Context> context,
                                 void* priv) {
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   Environment* env = Environment::GetCurrent(context);
 
   CHECK(

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -112,7 +112,7 @@ namespace {
 
 // Convert an int to a V8 Name (String or Symbol).
 MaybeLocal<String> Uint32ToName(Local<Context> context, uint32_t index) {
-  return Uint32::New(context->GetIsolate(), index)->ToString(context);
+  return Uint32::New(Isolate::GetCurrent(), index)->ToString(context);
 }
 
 }  // anonymous namespace
@@ -676,7 +676,7 @@ Intercepted ContextifyContext::PropertyDefinerCallback(
   }
 
   Local<Context> context = ctx->context();
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
 
   PropertyAttribute attributes = PropertyAttribute::None;
   bool is_declared =
@@ -1663,7 +1663,7 @@ static MaybeLocal<Function> CompileFunctionForCJSLoader(
     bool* cache_rejected,
     bool is_cjs_scope,
     ScriptCompiler::CachedData* cached_data) {
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   EscapableHandleScope scope(isolate);
 
   Local<Symbol> symbol = env->vm_dynamic_import_default_internal();

--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -311,7 +311,7 @@ std::shared_ptr<KVStore> KVStore::CreateMapKVStore() {
 
 Maybe<void> KVStore::AssignFromObject(Local<Context> context,
                                       Local<Object> entries) {
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   HandleScope handle_scope(isolate);
   Local<Array> keys;
   if (!entries->GetOwnPropertyNames(context).ToLocal(&keys))

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -633,7 +633,7 @@ v8::ModifyCodeGenerationFromStringsResult ModifyCodeGenerationFromStrings(
     v8::Local<v8::Context> context,
     v8::Local<v8::Value> source,
     bool is_code_like) {
-  HandleScope scope(context->GetIsolate());
+  HandleScope scope(Isolate::GetCurrent());
 
   if (context->GetNumberOfEmbedderDataFields() <=
       ContextEmbedderIndex::kAllowCodeGenerationFromStrings) {
@@ -1016,7 +1016,7 @@ const char* errno_string(int errorno) {
 }
 
 void PerIsolateMessageListener(Local<Message> message, Local<Value> error) {
-  Isolate* isolate = message->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   switch (message->ErrorLevel()) {
     case Isolate::MessageErrorLevel::kMessageWarning: {
       Environment* env = Environment::GetCurrent(isolate);
@@ -1134,7 +1134,7 @@ void Initialize(Local<Object> target,
   SetMethod(
       context, target, "triggerUncaughtException", TriggerUncaughtException);
 
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   Local<Object> exit_codes = Object::New(isolate);
   READONLY_PROPERTY(target, "exitCodes", exit_codes);
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3849,7 +3849,7 @@ void BindingData::Deserialize(Local<Context> context,
                               int index,
                               InternalFieldInfoBase* info) {
   DCHECK_IS_SNAPSHOT_SLOT(index);
-  HandleScope scope(context->GetIsolate());
+  HandleScope scope(Isolate::GetCurrent());
   Realm* realm = Realm::GetCurrent(context);
   InternalFieldInfo* casted_info = static_cast<InternalFieldInfo*>(info);
   BindingData* binding =

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -254,7 +254,7 @@ namespace {
 
 MaybeLocal<Function> GetEmitMessageFunction(Local<Context> context,
                                             IsolateData* isolate_data) {
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   Local<Object> per_context_bindings;
   Local<Value> emit_message_val;
   if (!GetPerContextExports(context, isolate_data)
@@ -269,7 +269,7 @@ MaybeLocal<Function> GetEmitMessageFunction(Local<Context> context,
 }
 
 MaybeLocal<Function> GetDOMException(Local<Context> context) {
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   Local<Object> per_context_bindings;
   Local<Value> domexception_ctor_val;
   if (!GetPerContextExports(context).ToLocal(&per_context_bindings) ||
@@ -284,7 +284,7 @@ MaybeLocal<Function> GetDOMException(Local<Context> context) {
 }
 
 void ThrowDataCloneException(Local<Context> context, Local<String> message) {
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   Local<Value> argv[] = {message,
                          FIXED_ONE_BYTE_STRING(isolate, "DataCloneError")};
   Local<Value> exception;
@@ -1462,7 +1462,7 @@ BaseObjectPtr<BaseObject> JSTransferable::Data::Deserialize(
 
 Maybe<bool> JSTransferable::Data::FinalizeTransferWrite(
     Local<Context> context, ValueSerializer* serializer) {
-  HandleScope handle_scope(context->GetIsolate());
+  HandleScope handle_scope(Isolate::GetCurrent());
   auto ret = serializer->WriteValue(context, PersistentToLocal::Strong(data_));
   data_.Reset();
   return ret;

--- a/src/node_modules.cc
+++ b/src/node_modules.cc
@@ -68,7 +68,7 @@ void BindingData::Deserialize(v8::Local<v8::Context> context,
                               int index,
                               InternalFieldInfoBase* info) {
   DCHECK_IS_SNAPSHOT_SLOT(index);
-  HandleScope scope(context->GetIsolate());
+  HandleScope scope(Isolate::GetCurrent());
   Realm* realm = Realm::GetCurrent(context);
   BindingData* binding = realm->AddBindingData<BindingData>(holder);
   CHECK_NOT_NULL(binding);
@@ -696,7 +696,7 @@ void BindingData::CreatePerContextProperties(Local<Object> target,
   Realm* realm = Realm::GetCurrent(context);
   realm->AddBindingData<BindingData>(target);
 
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   LocalVector<Value> compile_cache_status_values(isolate);
 
 #define V(status)                                                              \

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -743,7 +743,7 @@ void BindingData::Deserialize(Local<Context> context,
                               int index,
                               InternalFieldInfoBase* info) {
   DCHECK_IS_SNAPSHOT_SLOT(index);
-  v8::HandleScope scope(context->GetIsolate());
+  v8::HandleScope scope(Isolate::GetCurrent());
   Realm* realm = Realm::GetCurrent(context);
   // Recreate the buffer in the constructor.
   InternalFieldInfo* casted_info = static_cast<InternalFieldInfo*>(info);

--- a/src/node_realm.cc
+++ b/src/node_realm.cc
@@ -22,7 +22,7 @@ using v8::String;
 using v8::Value;
 
 Realm::Realm(Environment* env, v8::Local<v8::Context> context, Kind kind)
-    : env_(env), isolate_(context->GetIsolate()), kind_(kind) {
+    : env_(env), isolate_(Isolate::GetCurrent()), kind_(kind) {
   context_.Reset(isolate_, context);
   env->AssignToContext(context, this, ContextInfo(""));
   // The environment can also purge empty wrappers in the check callback,

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -402,7 +402,7 @@ static void PrintJavaScriptErrorProperties(JSONWriter* writer,
   if (!error.IsEmpty() && error->IsObject()) {
     TryCatch try_catch(isolate);
     Local<Object> error_obj = error.As<Object>();
-    Local<Context> context = error_obj->GetIsolate()->GetCurrentContext();
+    Local<Context> context = Isolate::GetCurrent()->GetCurrentContext();
     Local<Array> keys;
     if (!error_obj->GetOwnPropertyNames(context).ToLocal(&keys)) {
       return writer->json_objectend();  // the end of 'errorProperties'

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -1585,7 +1585,7 @@ void BindingData::Deserialize(Local<Context> context,
                               int index,
                               InternalFieldInfoBase* info) {
   DCHECK_IS_SNAPSHOT_SLOT(index);
-  v8::HandleScope scope(context->GetIsolate());
+  v8::HandleScope scope(Isolate::GetCurrent());
   Realm* realm = Realm::GetCurrent(context);
   // Recreate the buffer in the constructor.
   InternalFieldInfo* casted_info = static_cast<InternalFieldInfo*>(info);

--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -1864,7 +1864,7 @@ bool StatementSync::BindParams(const FunctionCallbackInfo<Value>& args) {
 
   if (args[0]->IsObject() && !args[0]->IsArrayBufferView()) {
     Local<Object> obj = args[0].As<Object>();
-    Local<Context> context = obj->GetIsolate()->GetCurrentContext();
+    Local<Context> context = Isolate::GetCurrent()->GetCurrentContext();
     Local<Array> keys;
     if (!obj->GetOwnPropertyNames(context).ToLocal(&keys)) {
       return false;

--- a/src/node_task_queue.cc
+++ b/src/node_task_queue.cc
@@ -48,7 +48,7 @@ void PromiseRejectCallback(PromiseRejectMessage message) {
   static std::atomic<uint64_t> rejectionsHandledAfter{0};
 
   Local<Promise> promise = message.GetPromise();
-  Isolate* isolate = promise->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   PromiseRejectEvent event = message.GetEvent();
 
   Environment* env = Environment::GetCurrent(isolate);

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -70,7 +70,7 @@ void BindingData::Deserialize(Local<Context> context,
                               int index,
                               InternalFieldInfoBase* info) {
   DCHECK_IS_SNAPSHOT_SLOT(index);
-  HandleScope scope(context->GetIsolate());
+  HandleScope scope(Isolate::GetCurrent());
   Realm* realm = Realm::GetCurrent(context);
   BindingData* binding = realm->AddBindingData<BindingData>(holder);
   CHECK_NOT_NULL(binding);

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -158,7 +158,7 @@ void BindingData::Deserialize(Local<Context> context,
                               int index,
                               InternalFieldInfoBase* info) {
   DCHECK_IS_SNAPSHOT_SLOT(index);
-  HandleScope scope(context->GetIsolate());
+  HandleScope scope(Isolate::GetCurrent());
   Realm* realm = Realm::GetCurrent(context);
   // Recreate the buffer in the constructor.
   InternalFieldInfo* casted_info = static_cast<InternalFieldInfo*>(info);

--- a/src/node_wasi.cc
+++ b/src/node_wasi.cc
@@ -50,7 +50,7 @@ using v8::WasmMemoryObject;
 static MaybeLocal<Value> WASIException(Local<Context> context,
                                        int errorno,
                                        const char* syscall) {
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   Environment* env = Environment::GetCurrent(context);
   CHECK_NOT_NULL(env);
   const char* err_name = uvwasi_embedder_err_code_to_string(errorno);
@@ -276,7 +276,7 @@ R WASI::WasiFunction<FT, F, R, Args...>::FastCallback(
     return EinvalError<R>();
   }
 
-  Isolate* isolate = receiver->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   HandleScope scope(isolate);
   if (wasi->memory_.IsEmpty()) {
     THROW_ERR_WASI_NOT_STARTED(isolate);

--- a/src/node_webstorage.cc
+++ b/src/node_webstorage.cc
@@ -57,7 +57,7 @@ using v8::Value;
   } while (0)
 
 static void ThrowQuotaExceededException(Local<Context> context) {
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   auto dom_exception_str = FIXED_ONE_BYTE_STRING(isolate, "DOMException");
   auto err_name = FIXED_ONE_BYTE_STRING(isolate, "QuotaExceededError");
   auto err_message =
@@ -433,7 +433,7 @@ Maybe<void> Storage::Store(Local<Name> key, Local<Value> value) {
 }
 
 static MaybeLocal<String> Uint32ToName(Local<Context> context, uint32_t index) {
-  return Uint32::New(context->GetIsolate(), index)->ToString(context);
+  return Uint32::New(Isolate::GetCurrent(), index)->ToString(context);
 }
 
 static void Clear(const FunctionCallbackInfo<Value>& info) {

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -1164,7 +1164,7 @@ void GetEnvMessagePort(const FunctionCallbackInfo<Value>& args) {
   Local<Object> port = env->message_port();
   CHECK_IMPLIES(!env->is_main_thread(), !port.IsEmpty());
   if (!port.IsEmpty()) {
-    CHECK_EQ(port->GetCreationContextChecked()->GetIsolate(),
+    CHECK_EQ(Isolate::GetCurrent(),
              args.GetIsolate());
     args.GetReturnValue().Set(port);
   }

--- a/src/timers.cc
+++ b/src/timers.cc
@@ -117,7 +117,7 @@ void BindingData::Deserialize(Local<Context> context,
                               int index,
                               InternalFieldInfoBase* info) {
   DCHECK_IS_SNAPSHOT_SLOT(index);
-  v8::HandleScope scope(context->GetIsolate());
+  v8::HandleScope scope(Isolate::GetCurrent());
   Realm* realm = Realm::GetCurrent(context);
   // Recreate the buffer in the constructor.
   BindingData* binding = realm->AddBindingData<BindingData>(holder);

--- a/src/util.cc
+++ b/src/util.cc
@@ -391,7 +391,7 @@ void SetMethod(Local<v8::Context> context,
                Local<v8::Object> that,
                const std::string_view name,
                v8::FunctionCallback callback) {
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   Local<v8::Function> function =
       NewFunctionTemplate(isolate,
                           callback,
@@ -452,7 +452,7 @@ void SetFastMethod(Local<v8::Context> context,
                    const std::string_view name,
                    v8::FunctionCallback slow_callback,
                    const v8::CFunction* c_function) {
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   Local<v8::Function> function =
       NewFunctionTemplate(isolate,
                           slow_callback,
@@ -474,7 +474,7 @@ void SetFastMethodNoSideEffect(Local<v8::Context> context,
                                const std::string_view name,
                                v8::FunctionCallback slow_callback,
                                const v8::CFunction* c_function) {
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   Local<v8::Function> function =
       NewFunctionTemplate(isolate,
                           slow_callback,
@@ -562,7 +562,7 @@ void SetMethodNoSideEffect(Local<v8::Context> context,
                            Local<v8::Object> that,
                            const std::string_view name,
                            v8::FunctionCallback callback) {
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   Local<v8::Function> function =
       NewFunctionTemplate(isolate,
                           callback,
@@ -689,7 +689,7 @@ void SetConstructorFunction(Local<v8::Context> context,
                             const char* name,
                             Local<v8::FunctionTemplate> tmpl,
                             SetConstructorFunctionFlag flag) {
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   SetConstructorFunction(
       context, that, OneByteString(isolate, name), tmpl, flag);
 }

--- a/src/util.h
+++ b/src/util.h
@@ -746,7 +746,7 @@ inline v8::MaybeLocal<v8::Value> ToV8Value(
 // Variation on NODE_DEFINE_CONSTANT that sets a String value.
 #define NODE_DEFINE_STRING_CONSTANT(target, name, constant)                    \
   do {                                                                         \
-    v8::Isolate* isolate = target->GetIsolate();                               \
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();                          \
     v8::Local<v8::String> constant_name =                                      \
         v8::String::NewFromUtf8(isolate, name).ToLocalChecked();               \
     v8::Local<v8::String> constant_value =                                     \

--- a/test/addons/async-cleanup-hook/binding.cc
+++ b/test/addons/async-cleanup-hook/binding.cc
@@ -42,15 +42,15 @@ void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Value> module,
                 v8::Local<v8::Context> context) {
   AsyncData* data = new AsyncData();
-  data->isolate = context->GetIsolate();
+  data->isolate = v8::Isolate::GetCurrent();
   auto handle = node::AddEnvironmentCleanupHook(
-      context->GetIsolate(),
+      v8::Isolate::GetCurrent(),
       AsyncCleanupHook,
       data);
   data->handle = std::move(handle);
 
   auto must_not_call_handle = node::AddEnvironmentCleanupHook(
-      context->GetIsolate(),
+      v8::Isolate::GetCurrent(),
       MustNotCall,
       nullptr);
   node::RemoveEnvironmentCleanupHook(std::move(must_not_call_handle));

--- a/test/addons/cppgc-object/binding.cc
+++ b/test/addons/cppgc-object/binding.cc
@@ -27,7 +27,7 @@ class CppGCed : public v8::Object::Wrappable {
 
   static v8::Local<v8::Function> GetConstructor(
       v8::Local<v8::Context> context) {
-    auto ft = v8::FunctionTemplate::New(context->GetIsolate(), New);
+    auto ft = v8::FunctionTemplate::New(v8::Isolate::GetCurrent(), New);
     return ft->GetFunction(context).ToLocalChecked();
   }
 

--- a/test/addons/esm-export/binding-export-primitive.cc
+++ b/test/addons/esm-export/binding-export-primitive.cc
@@ -5,7 +5,7 @@
 static void InitModule(v8::Local<v8::Object> exports,
                        v8::Local<v8::Value> module_val,
                        v8::Local<v8::Context> context) {
-  v8::Isolate* isolate = context->GetIsolate();
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
   v8::Local<v8::Object> module = module_val.As<v8::Object>();
   module
       ->Set(context,

--- a/test/addons/heap-profiler/binding.cc
+++ b/test/addons/heap-profiler/binding.cc
@@ -17,7 +17,7 @@ inline void Test(const v8::FunctionCallbackInfo<v8::Value>& args) {
 }
 
 inline void Initialize(v8::Local<v8::Object> binding) {
-  v8::Isolate* const isolate = binding->GetIsolate();
+  v8::Isolate* const isolate = v8::Isolate::GetCurrent();
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
   binding->Set(context, v8::String::NewFromUtf8(
         isolate, "test").ToLocalChecked(),

--- a/test/addons/hello-world/binding.cc
+++ b/test/addons/hello-world/binding.cc
@@ -19,7 +19,7 @@ NODE_MODULE_INITIALIZER(v8::Local<v8::Object> exports,
 static void FakeInit(v8::Local<v8::Object> exports,
                      v8::Local<v8::Value> module,
                      v8::Local<v8::Context> context) {
-  auto isolate = context->GetIsolate();
+  auto isolate = v8::Isolate::GetCurrent();
   auto exception = v8::Exception::Error(v8::String::NewFromUtf8(isolate,
       "FakeInit should never run!").ToLocalChecked());
   isolate->ThrowException(exception);

--- a/test/addons/new-target/binding.cc
+++ b/test/addons/new-target/binding.cc
@@ -10,7 +10,7 @@ inline void NewClass(const v8::FunctionCallbackInfo<v8::Value>& args) {
 }
 
 inline void Initialize(v8::Local<v8::Object> binding) {
-  auto isolate = binding->GetIsolate();
+  auto isolate = v8::Isolate::GetCurrent();
   auto context = isolate->GetCurrentContext();
   binding->Set(context, v8::String::NewFromUtf8(
         isolate, "Class").ToLocalChecked(),

--- a/test/addons/openssl-binding/binding.cc
+++ b/test/addons/openssl-binding/binding.cc
@@ -38,7 +38,7 @@ inline void Hash(const v8::FunctionCallbackInfo<v8::Value>& info) {
 inline void Initialize(v8::Local<v8::Object> exports,
                        v8::Local<v8::Value> module,
                        v8::Local<v8::Context> context) {
-  auto isolate = context->GetIsolate();
+  auto isolate = v8::Isolate::GetCurrent();
   auto key = v8::String::NewFromUtf8(
       isolate, "randomBytes").ToLocalChecked();
   auto value = v8::FunctionTemplate::New(isolate, RandomBytes)

--- a/test/addons/worker-addon/binding.cc
+++ b/test/addons/worker-addon/binding.cc
@@ -52,18 +52,18 @@ void Initialize(Local<Object> exports,
                 Local<Value> module,
                 Local<Context> context) {
   node::AddEnvironmentCleanupHook(
-      context->GetIsolate(),
+      v8::Isolate::GetCurrent(),
       Cleanup,
       const_cast<void*>(static_cast<const void*>("cleanup")));
-  node::AddEnvironmentCleanupHook(context->GetIsolate(), Dummy, nullptr);
-  node::RemoveEnvironmentCleanupHook(context->GetIsolate(), Dummy, nullptr);
+  node::AddEnvironmentCleanupHook(v8::Isolate::GetCurrent(), Dummy, nullptr);
+  node::RemoveEnvironmentCleanupHook(v8::Isolate::GetCurrent(), Dummy, nullptr);
 
   if (getenv("addExtraItemToEventLoop") != nullptr) {
     // Add an item to the event loop that we do not clean up in order to make
     // sure that for the main thread, this addon's memory persists even after
     // the Environment instance has been destroyed.
     static uv_async_t extra_async;
-    uv_loop_t* loop = node::GetCurrentEventLoop(context->GetIsolate());
+    uv_loop_t* loop = node::GetCurrentEventLoop(v8::Isolate::GetCurrent());
     int err = uv_async_init(loop, &extra_async, [](uv_async_t*) {});
     assert(err == 0);
     uv_unref(reinterpret_cast<uv_handle_t*>(&extra_async));

--- a/test/addons/worker-buffer-callback/binding.cc
+++ b/test/addons/worker-buffer-callback/binding.cc
@@ -18,7 +18,7 @@ void GetFreeCallCount(const FunctionCallbackInfo<Value>& args) {
 void Initialize(Local<Object> exports,
                 Local<Value> module,
                 Local<Context> context) {
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = v8::Isolate::GetCurrent();
   NODE_SET_METHOD(exports, "getFreeCallCount", GetFreeCallCount);
 
   char* data = new char;

--- a/test/addons/zlib-binding/binding.cc
+++ b/test/addons/zlib-binding/binding.cc
@@ -44,7 +44,7 @@ inline void CompressBytes(const v8::FunctionCallbackInfo<v8::Value>& info) {
 inline void Initialize(v8::Local<v8::Object> exports,
                        v8::Local<v8::Value> module,
                        v8::Local<v8::Context> context) {
-  auto isolate = context->GetIsolate();
+  auto isolate = v8::Isolate::GetCurrent();
   auto key = v8::String::NewFromUtf8(
       isolate, "compressBytes").ToLocalChecked();
   auto value = v8::FunctionTemplate::New(isolate, CompressBytes)

--- a/test/cctest/test_cppgc.cc
+++ b/test/cctest/test_cppgc.cc
@@ -30,7 +30,7 @@ class CppGCed : public v8::Object::Wrappable {
 
   static v8::Local<v8::Function> GetConstructor(
       v8::Local<v8::Context> context) {
-    auto ft = v8::FunctionTemplate::New(context->GetIsolate(), New);
+    auto ft = v8::FunctionTemplate::New(v8::Isolate::GetCurrent(), New);
     return ft->GetFunction(context).ToLocalChecked();
   }
 

--- a/test/cctest/test_linked_binding.cc
+++ b/test/cctest/test_linked_binding.cc
@@ -9,7 +9,7 @@ void InitializeBinding(v8::Local<v8::Object> exports,
                        v8::Local<v8::Value> module,
                        v8::Local<v8::Context> context,
                        void* priv) {
-  v8::Isolate* isolate = context->GetIsolate();
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
   exports
       ->Set(context,
             v8::String::NewFromOneByte(isolate,
@@ -51,7 +51,7 @@ void InitializeLocalBinding(v8::Local<v8::Object> exports,
                             v8::Local<v8::Context> context,
                             void* priv) {
   ++*static_cast<int*>(priv);
-  v8::Isolate* isolate = context->GetIsolate();
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
   exports
       ->Set(context,
             v8::String::NewFromOneByte(isolate,


### PR DESCRIPTION
Replace any call to `Object::GetIsolate()` by `Isolate::GetCurrent()`.
This does not change anything, as `Object::GetIsolate()` is already implemented as `Isolate::GetCurrent()` under the hood.

Medium term, some of the new calls could / should be replaced by passing an existing isolate pointer, which can be more efficient depending on usage patterns and the platform that we execute on.

One drive-by fix: Replace `linked_requests_data.As<Array>()` by `linked_requests_data.As<Value>().As<Array>()` to fix debug builds.