### PR TITLE
Avoid pollution of node cflags by deps/ncrypto/unofficial.gni

### DIFF
--- a/deps/ncrypto/unofficial.gni
+++ b/deps/ncrypto/unofficial.gni
@@ -8,10 +8,12 @@ import("$node_v8_path/gni/v8.gni")
 # The actual configurations are put inside a template in unofficial.gni to
 # prevent accidental edits from contributors.
 template("ncrypto_gn_build") {
-  config("ncrypto_config") {
+  config("ncrypto_external_config") {
     include_dirs = [ "." ]
+  }
+  config("ncrypto_internal_config") {
     cflags = [
-      "-Wno-deprecated-declarations",
+      # "-Wno-deprecated-declarations",
       "-Wno-pessimizing-move",
       "-Wno-shadow",
       "-Wno-unused-variable",
@@ -27,7 +29,8 @@ template("ncrypto_gn_build") {
 
   source_set(target_name) {
     forward_variables_from(invoker, "*")
-    public_configs = [ ":ncrypto_config" ]
+    configs += [ ":ncrypto_internal_config" ]
+    public_configs = [ ":ncrypto_external_config" ]
     sources = gypi_values.ncrypto_sources
     deps = [ "$node_openssl_path" ]
   }


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Fix `deps/ncrypto` GN config to avoid pollution of Node's `cflags`.

It used to disable deprecation warnings for the whole Node regardless of the state of `node_enable_deprecated_declarations_warnings` GN argument.