### PR TITLE
Adjust to_phase_constant to allow new enumaration for deferred imports

### DIFF
--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -563,8 +563,9 @@ ModulePhase to_phase_constant(ModuleImportPhase phase) {
       return kEvaluationPhase;
     case ModuleImportPhase::kSource:
       return kSourcePhase;
+    default:
+      UNREACHABLE();
   }
-  UNREACHABLE();
 }
 
 static Local<Object> createImportAttributesContainer(


### PR DESCRIPTION
This changes allow us include a new `ModuleImportPhase::kDefer` that is needed to [https://crrev.com/c/7017517](https://crrev.com/c/7017517).