### PR TITLE
[node][wasm] Avoid deprecated API

### DIFF
--- a/src/node_wasm_web_api.cc
+++ b/src/node_wasm_web_api.cc
@@ -132,7 +132,7 @@ void WasmStreamingObject::Finish(const FunctionCallbackInfo<Value>& args) {
   CHECK(obj->streaming_);
 
   CHECK_EQ(args.Length(), 0);
-  obj->streaming_->Finish();
+  obj->streaming_->Finish(WasmStreaming::ModuleCachingCallback{});
 }
 
 void WasmStreamingObject::Abort(const FunctionCallbackInfo<Value>& args) {


### PR DESCRIPTION
Use the new API which gets a `ModuleCachingCallback` parameter. The old API is deprecated and will soon be removed, see https://crrev.com/c/7078551.
