### PR TITLE
[node] Avoid deprecated FixedArray::Get

### DIFF
--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -755,7 +755,7 @@ MaybeLocal<Module> BuiltinLoader::LoadBuiltinSourceTextModule(Realm* realm,
   // Pre-fetch all dependencies.
   if (requests->Length() > 0) {
     for (int i = 0; i < requests->Length(); i++) {
-      Local<ModuleRequest> req = requests->Get(context, i).As<ModuleRequest>();
+      Local<ModuleRequest> req = requests->Get(i).As<ModuleRequest>();
       std::string specifier =
           Utf8Value(isolate, req->GetSpecifier()).ToString();
       std::string resolved_id = ResolveRequestForBuiltin(specifier);


### PR DESCRIPTION
Use the method without context parameter; the old API is deprecated, see https://crrev.com/c/7141498.