### PR TITLE
Stop using deprecated v8::PropertyCallbackInfo<T>::This().

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -463,7 +463,7 @@ ContextifyContext* ContextifyContext::Get(const PropertyCallbackInfo<T>& args) {
   // args.GetIsolate()->GetCurrentContext() and take the pointer at
   // ContextEmbedderIndex::kContextifyContext, as V8 is supposed to
   // push the creation context before invoking these callbacks.
-  return Get(args.This());
+  return Get(args.HolderV2());
 }
 
 ContextifyContext* ContextifyContext::Get(Local<Object> object) {
@@ -597,10 +597,21 @@ Intercepted ContextifyContext::PropertySetterCallback(
     return Intercepted::kNo;
   }
 
+  // V8 comment: As long as the context is not detached the contextual accesses
+  // are the same as regular accesses to `context->Global()`s data property.
+  // The only difference is that after detaching `args.Holder()` will
+  // become a new identity and will no longer be equal to `context->Global()`.
+  // TODO(Node.js): revise the code below as the "contextual"-ness of the
+  // store is not actually relevant here. Also, new variable declaration is
+  // reported by V8 via PropertyDefinerCallback.
+  bool is_declared = is_declared_on_global_proxy || is_declared_on_sandbox;
+
+/*
   // true for x = 5
   // false for this.x = 5
   // false for Object.defineProperty(this, 'foo', ...)
   // false for vmResult.x = 5 where vmResult = vm.runInContext();
+
   bool is_contextual_store = ctx->global_proxy() != args.This();
 
   // Indicator to not return before setting (undeclared) function declarations
@@ -617,7 +628,7 @@ Intercepted ContextifyContext::PropertySetterCallback(
       !is_function) {
     return Intercepted::kNo;
   }
-
+*/
   if (!is_declared && property->IsSymbol()) {
     return Intercepted::kNo;
   }


### PR DESCRIPTION
... and use v8::PropertyCallbackInfo<T>::HolderV2() instead.

Cleanup irrelevant handling of "contextual" stores in ContextifyContext interceptor.

See https://github.com/nodejs/node/issues/60616.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
