### PR TITLE
Add type tags to uses of v8::External

### DIFF
--- a/test/addons/async-resource/binding.cc
+++ b/test/addons/async-resource/binding.cc
@@ -1,7 +1,8 @@
-#include "node.h"
-
 #include <assert.h>
+
 #include <vector>
+
+#include "node.h"
 
 namespace {
 
@@ -23,9 +24,7 @@ class CustomAsyncResource : public AsyncResource {
  public:
   CustomAsyncResource(Isolate* isolate, Local<Object> resource)
       : AsyncResource(isolate, resource, "CustomAsyncResource") {}
-  ~CustomAsyncResource() {
-    custom_async_resource_destructor_calls++;
-  }
+  ~CustomAsyncResource() { custom_async_resource_destructor_calls++; }
 };
 
 void CreateAsyncResource(const FunctionCallbackInfo<Value>& args) {
@@ -39,26 +38,27 @@ void CreateAsyncResource(const FunctionCallbackInfo<Value>& args) {
     r = new AsyncResource(isolate, args[0].As<Object>(), "foobär");
   }
 
-  args.GetReturnValue().Set(
-      External::New(isolate, static_cast<void*>(r)));
+  args.GetReturnValue().Set(External::New(isolate, static_cast<void*>(r),
+                                          v8::kExternalPointerTypeTagDefault));
 }
 
 void DestroyAsyncResource(const FunctionCallbackInfo<Value>& args) {
   assert(args[0]->IsExternal());
-  auto r = static_cast<AsyncResource*>(args[0].As<External>()->Value());
+  auto r = static_cast<AsyncResource*>(
+      args[0].As<External>()->Value(v8::kExternalPointerTypeTagDefault));
   delete r;
 }
 
 void CallViaFunction(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
   assert(args[0]->IsExternal());
-  auto r = static_cast<AsyncResource*>(args[0].As<External>()->Value());
+  auto r = static_cast<AsyncResource*>(
+      args[0].As<External>()->Value(v8::kExternalPointerTypeTagDefault));
 
-  Local<String> name =
-      String::NewFromUtf8(isolate, "methöd").ToLocalChecked();
-  Local<Value> fn =
-      r->get_resource()->Get(isolate->GetCurrentContext(), name)
-      .ToLocalChecked();
+  Local<String> name = String::NewFromUtf8(isolate, "methöd").ToLocalChecked();
+  Local<Value> fn = r->get_resource()
+                        ->Get(isolate->GetCurrentContext(), name)
+                        .ToLocalChecked();
   assert(fn->IsFunction());
 
   Local<Value> arg = Integer::New(isolate, 42);
@@ -69,10 +69,10 @@ void CallViaFunction(const FunctionCallbackInfo<Value>& args) {
 void CallViaString(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
   assert(args[0]->IsExternal());
-  auto r = static_cast<AsyncResource*>(args[0].As<External>()->Value());
+  auto r = static_cast<AsyncResource*>(
+      args[0].As<External>()->Value(v8::kExternalPointerTypeTagDefault));
 
-  Local<String> name =
-      String::NewFromUtf8(isolate, "methöd").ToLocalChecked();
+  Local<String> name = String::NewFromUtf8(isolate, "methöd").ToLocalChecked();
 
   Local<Value> arg = Integer::New(isolate, 42);
   MaybeLocal<Value> ret = r->MakeCallback(name, 1, &arg);
@@ -82,7 +82,8 @@ void CallViaString(const FunctionCallbackInfo<Value>& args) {
 void CallViaUtf8Name(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
   assert(args[0]->IsExternal());
-  auto r = static_cast<AsyncResource*>(args[0].As<External>()->Value());
+  auto r = static_cast<AsyncResource*>(
+      args[0].As<External>()->Value(v8::kExternalPointerTypeTagDefault));
 
   Local<Value> arg = Integer::New(isolate, 42);
   MaybeLocal<Value> ret = r->MakeCallback("methöd", 1, &arg);
@@ -91,19 +92,22 @@ void CallViaUtf8Name(const FunctionCallbackInfo<Value>& args) {
 
 void GetAsyncId(const FunctionCallbackInfo<Value>& args) {
   assert(args[0]->IsExternal());
-  auto r = static_cast<AsyncResource*>(args[0].As<External>()->Value());
+  auto r = static_cast<AsyncResource*>(
+      args[0].As<External>()->Value(v8::kExternalPointerTypeTagDefault));
   args.GetReturnValue().Set(r->get_async_id());
 }
 
 void GetTriggerAsyncId(const FunctionCallbackInfo<Value>& args) {
   assert(args[0]->IsExternal());
-  auto r = static_cast<AsyncResource*>(args[0].As<External>()->Value());
+  auto r = static_cast<AsyncResource*>(
+      args[0].As<External>()->Value(v8::kExternalPointerTypeTagDefault));
   args.GetReturnValue().Set(r->get_trigger_async_id());
 }
 
 void GetResource(const FunctionCallbackInfo<Value>& args) {
   assert(args[0]->IsExternal());
-  auto r = static_cast<AsyncResource*>(args[0].As<External>()->Value());
+  auto r = static_cast<AsyncResource*>(
+      args[0].As<External>()->Value(v8::kExternalPointerTypeTagDefault));
   args.GetReturnValue().Set(r->get_resource());
 }
 


### PR DESCRIPTION
The variants without type tags are going to be removed. I ran clang-format on the source file, which is the reason why there are some additional changes.

Bug: 436799229

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
