### PR TITLE
Disable node snapshots

### DIFF
--- a/node.gni
+++ b/node.gni
@@ -68,7 +68,12 @@ declare_args() {
   # TODO(zcbenz): There are few broken things for now:
   #   1. cross-os compilation is not supported.
   #   2. node_mksnapshot crashes when cross-compiling for x64 from arm64.
-  node_use_node_snapshot = (host_os == target_os) && !(host_cpu == "arm64" && target_cpu == "x64")
+  # node_use_node_snapshot = (host_os == target_os) && !(host_cpu == "arm64" && target_cpu == "x64")
+
+  # Disable snapshot for now. Node.js currently puts `FunctionTemplateInfo`
+  # objects into the snapshot, but that only works for `FunctionTemplateInfo`
+  # objects of API functions that do not support fast API calls.
+  node_use_node_snapshot = false
 
   # Build with Amaro (TypeScript utils).
   node_use_amaro = true


### PR DESCRIPTION
A security fix in V8 makes it impossible to put FunctionTemplateInfo objects of API functions with fast API callbacks into the snapshot. As Node.js does that so far, this PR disables node snapshots. In the future, FunctionTemplateInfo objects without fast API callbacks could be added back to the snapshot.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
