### PR TITLE
Skip snapshot tests when snapshots are disabled

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -110,6 +110,41 @@ test-async-context-frame: SKIP
 test-fs-stat-bigint: SKIP
 test-sqlite-session: SKIP
 
+# These tests create node snapshots even when node snapshots are disabled.
+# Node snapshots don't work at the moment because FunctionTemplateInfo
+# objects with fast API callbacks are put into the snapshot. However, the way
+# FunctionTemplateInfo objects reference fast API callbacks at the moment causes
+# security issues, and the fix references fast API callbacks via a dynamically
+# allocated C++ object, which cannot be put into the snapshot.
+test-snapshot-stack-trace-limit-mutation: SKIP
+test-inspect-address-in-use: SKIP
+test-snapshot-api: SKIP
+test-snapshot-argv1: SKIP
+test-snapshot-basic: SKIP
+test-snapshot-child-process-sync: SKIP
+test-snapshot-cjs-main: SKIP
+test-snapshot-config: SKIP
+test-snapshot-console: SKIP
+test-snapshot-coverage: SKIP
+test-snapshot-cwd: SKIP
+test-snapshot-error: SKIP
+test-snapshot-eval: SKIP
+test-snapshot-gzip: SKIP
+test-snapshot-incompatible: SKIP
+test-snapshot-net: SKIP
+test-snapshot-reproducible: SKIP
+test-snapshot-stack-trace-limit: SKIP
+test-snapshot-typescript: SKIP
+test-snapshot-umd: SKIP
+test-snapshot-warning: SKIP
+test-snapshot-weak-reference: SKIP
+test-snapshot-worker: SKIP
+test-snapshot-namespaced-builtin: SKIP
+test-snapshot-dns-resolve-localhost: SKIP
+test-snapshot-dns-lookup-localhost: SKIP
+test-snapshot-dns-lookup-localhost-promise: SKIP
+test-snapshot-dns-resolve-localhost-promise: SKIP
+
 [$system==win32]
 
 # Until V8 provides a better way to check for flag mismatch without


### PR DESCRIPTION
These tests create node snapshots even when node snapshots are disabled. Node snapshots don't work at the moment because FunctionTemplateInfo objects with fast API callbacks are put into the snapshot, but this causes security issues.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
