### PR TITLE
build,simdjson: export symbols in component build

### DIFF
--- a/deps/simdjson/unofficial.gni
+++ b/deps/simdjson/unofficial.gni
@@ -18,5 +18,10 @@ template("simdjson_gn_build") {
     forward_variables_from(invoker, "*")
     public_configs = [ ":simdjson_config" ]
     sources = gypi_values.simdjson_sources
+
+    if (is_component_build && is_posix) {
+      configs -= [ "//build/config/gcc:symbol_visibility_hidden" ]
+      configs += [ "//build/config/gcc:symbol_visibility_default" ]
+    }
   }
 }


### PR DESCRIPTION
In component builds on POSIX, simdjson.h defines SIMDJSON_DLLIMPORTEXPORT as empty. Combined with Chromium's default [-fvisibility=hidden](https://source.chromium.org/chromium/chromium/src/+/main:build/config/BUILDCONFIG.gn;l=399-404), this causes all simdjson symbols to be hidden, leading to:

```
  ld.lld: error: undefined symbol: simdjson::internal::to_chars(...)
  ld.lld: error: undefined symbol: simdjson::internal::structural_or_whitespace_negated
  ld.lld: error: undefined symbol: simdjson::internal::error_codes
  ld.lld: error: undefined symbol: simdjson::get_active_implementation()
```

Switch the simdjson component to default symbol visibility on POSIX similar to deps/uv. Addresses the link time failure in https://ci.chromium.org/ui/p/node-ci/builders/try/node_ci_linux64_dbg