### PR TITLE
[v8] Migrate from deprecated setter/definer callback signatures

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -566,7 +566,7 @@ Intercepted ContextifyContext::PropertyGetterCallback(
 Intercepted ContextifyContext::PropertySetterCallback(
     Local<Name> property,
     Local<Value> value,
-    const PropertyCallbackInfo<void>& args) {
+    const PropertyCallbackInfo<Boolean>& args) {
   ContextifyContext* ctx = ContextifyContext::Get(args);
 
   // Still initializing
@@ -689,7 +689,7 @@ Intercepted ContextifyContext::PropertyDescriptorCallback(
 Intercepted ContextifyContext::PropertyDefinerCallback(
     Local<Name> property,
     const PropertyDescriptor& desc,
-    const PropertyCallbackInfo<void>& args) {
+    const PropertyCallbackInfo<Boolean>& args) {
   ContextifyContext* ctx = ContextifyContext::Get(args);
 
   // Still initializing
@@ -898,7 +898,7 @@ Intercepted ContextifyContext::IndexedPropertyGetterCallback(
 Intercepted ContextifyContext::IndexedPropertySetterCallback(
     uint32_t index,
     Local<Value> value,
-    const PropertyCallbackInfo<void>& args) {
+    const PropertyCallbackInfo<Boolean>& args) {
   ContextifyContext* ctx = ContextifyContext::Get(args);
 
   // Still initializing
@@ -927,7 +927,7 @@ Intercepted ContextifyContext::IndexedPropertyDescriptorCallback(
 Intercepted ContextifyContext::IndexedPropertyDefinerCallback(
     uint32_t index,
     const PropertyDescriptor& desc,
-    const PropertyCallbackInfo<void>& args) {
+    const PropertyCallbackInfo<Boolean>& args) {
   ContextifyContext* ctx = ContextifyContext::Get(args);
 
   // Still initializing

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -153,14 +153,14 @@ class ContextifyContext final : CPPGC_MIXIN(ContextifyContext) {
   static v8::Intercepted PropertySetterCallback(
       v8::Local<v8::Name> property,
       v8::Local<v8::Value> value,
-      const v8::PropertyCallbackInfo<void>& args);
+      const v8::PropertyCallbackInfo<v8::Boolean>& args);
   static v8::Intercepted PropertyDescriptorCallback(
       v8::Local<v8::Name> property,
       const v8::PropertyCallbackInfo<v8::Value>& args);
   static v8::Intercepted PropertyDefinerCallback(
       v8::Local<v8::Name> property,
       const v8::PropertyDescriptor& desc,
-      const v8::PropertyCallbackInfo<void>& args);
+      const v8::PropertyCallbackInfo<v8::Boolean>& args);
   static v8::Intercepted PropertyDeleterCallback(
       v8::Local<v8::Name> property,
       const v8::PropertyCallbackInfo<v8::Boolean>& args);
@@ -173,13 +173,13 @@ class ContextifyContext final : CPPGC_MIXIN(ContextifyContext) {
   static v8::Intercepted IndexedPropertySetterCallback(
       uint32_t index,
       v8::Local<v8::Value> value,
-      const v8::PropertyCallbackInfo<void>& args);
+      const v8::PropertyCallbackInfo<v8::Boolean>& args);
   static v8::Intercepted IndexedPropertyDescriptorCallback(
       uint32_t index, const v8::PropertyCallbackInfo<v8::Value>& args);
   static v8::Intercepted IndexedPropertyDefinerCallback(
       uint32_t index,
       const v8::PropertyDescriptor& desc,
-      const v8::PropertyCallbackInfo<void>& args);
+      const v8::PropertyCallbackInfo<v8::Boolean>& args);
   static v8::Intercepted IndexedPropertyDeleterCallback(
       uint32_t index, const v8::PropertyCallbackInfo<v8::Boolean>& args);
   static void IndexedPropertyEnumeratorCallback(

--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -450,7 +450,7 @@ static Intercepted EnvGetter(Local<Name> property,
 
 static Intercepted EnvSetter(Local<Name> property,
                              Local<Value> value,
-                             const PropertyCallbackInfo<void>& info) {
+                             const PropertyCallbackInfo<Boolean>& info) {
   Environment* env = Environment::GetCurrent(info);
   CHECK(env->has_run_bootstrapping_code());
   // calling env->EmitProcessEnvWarning() sets a variable indicating that
@@ -531,7 +531,7 @@ static void EnvEnumerator(const PropertyCallbackInfo<Array>& info) {
 
 static Intercepted EnvDefiner(Local<Name> property,
                               const PropertyDescriptor& desc,
-                              const PropertyCallbackInfo<void>& info) {
+                              const PropertyCallbackInfo<Boolean>& info) {
   Environment* env = Environment::GetCurrent(info);
   if (desc.has_value()) {
     if (!desc.has_writable() ||
@@ -581,7 +581,7 @@ static Intercepted EnvGetterIndexed(uint32_t index,
 
 static Intercepted EnvSetterIndexed(uint32_t index,
                                     Local<Value> value,
-                                    const PropertyCallbackInfo<void>& info) {
+                                    const PropertyCallbackInfo<Boolean>& info) {
   Environment* env = Environment::GetCurrent(info);
   Local<Name> name = Uint32ToString(env->context(), index);
   return EnvSetter(name, value, info);
@@ -601,9 +601,10 @@ static Intercepted EnvDeleterIndexed(
   return EnvDeleter(name, info);
 }
 
-static Intercepted EnvDefinerIndexed(uint32_t index,
-                                     const PropertyDescriptor& desc,
-                                     const PropertyCallbackInfo<void>& info) {
+static Intercepted EnvDefinerIndexed(
+    uint32_t index,
+    const PropertyDescriptor& desc,
+    const PropertyCallbackInfo<Boolean>& info) {
   Environment* env = Environment::GetCurrent(info);
   Local<Name> name = Uint32ToString(env->context(), index);
   return EnvDefiner(name, desc, info);

--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -20,18 +20,18 @@ class ExternalReferenceRegistry {
 #define ALLOWED_EXTERNAL_REFERENCE_TYPES(V)                                    \
   V(v8::FunctionCallback)                                                      \
   V(v8::AccessorNameGetterCallback)                                            \
-  V(v8::AccessorNameSetterCallback)                                            \
+  V(v8::AccessorNameSetterCallbackV2)                                          \
   V(v8::NamedPropertyGetterCallback)                                           \
-  V(v8::NamedPropertyDefinerCallback)                                          \
+  V(v8::NamedPropertyDefinerCallbackV2)                                        \
   V(v8::NamedPropertyDeleterCallback)                                          \
   V(v8::NamedPropertyEnumeratorCallback)                                       \
   V(v8::NamedPropertyQueryCallback)                                            \
-  V(v8::NamedPropertySetterCallback)                                           \
-  V(v8::IndexedPropertyGetterCallbackV2)                                       \
-  V(v8::IndexedPropertySetterCallbackV2)                                       \
-  V(v8::IndexedPropertyDefinerCallbackV2)                                      \
-  V(v8::IndexedPropertyDeleterCallbackV2)                                      \
-  V(v8::IndexedPropertyQueryCallbackV2)                                        \
+  V(v8::NamedPropertySetterCallbackV2)                                         \
+  V(v8::IndexedPropertyGetterCallback)                                         \
+  V(v8::IndexedPropertySetterCallback)                                         \
+  V(v8::IndexedPropertyDefinerCallback)                                        \
+  V(v8::IndexedPropertyDeleterCallback)                                        \
+  V(v8::IndexedPropertyQueryCallback)                                          \
   V(const v8::String::ExternalStringResourceBase*)
 
 #define V(ExternalReferenceType)                                               \

--- a/src/node_process_object.cc
+++ b/src/node_process_object.cc
@@ -12,6 +12,7 @@
 #include <climits>  // PATH_MAX
 
 namespace node {
+using v8::Boolean;
 using v8::Context;
 using v8::EscapableHandleScope;
 using v8::Function;
@@ -40,7 +41,7 @@ static void ProcessTitleGetter(Local<Name> property,
 
 static void ProcessTitleSetter(Local<Name> property,
                                Local<Value> value,
-                               const PropertyCallbackInfo<void>& info) {
+                               const PropertyCallbackInfo<Boolean>& info) {
   node::Utf8Value title(info.GetIsolate(), value);
   TRACE_EVENT_METADATA1(
       "__metadata", "process_name", "name", TRACE_STR_COPY(*title));
@@ -57,7 +58,7 @@ static void DebugPortGetter(Local<Name> property,
 
 static void DebugPortSetter(Local<Name> property,
                             Local<Value> value,
-                            const PropertyCallbackInfo<void>& info) {
+                            const PropertyCallbackInfo<Boolean>& info) {
   Environment* env = Environment::GetCurrent(info);
   int32_t port = value->Int32Value(env->context()).FromMaybe(0);
 

--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -774,7 +774,7 @@ Intercepted DatabaseSyncLimits::LimitsGetter(
 Intercepted DatabaseSyncLimits::LimitsSetter(
     Local<Name> property,
     Local<Value> value,
-    const PropertyCallbackInfo<void>& info) {
+    const PropertyCallbackInfo<Boolean>& info) {
   if (!property->IsString()) {
     return Intercepted::kNo;
   }

--- a/src/node_sqlite.h
+++ b/src/node_sqlite.h
@@ -433,7 +433,7 @@ class DatabaseSyncLimits : public BaseObject {
   static v8::Intercepted LimitsSetter(
       v8::Local<v8::Name> property,
       v8::Local<v8::Value> value,
-      const v8::PropertyCallbackInfo<void>& info);
+      const v8::PropertyCallbackInfo<v8::Boolean>& info);
   static v8::Intercepted LimitsQuery(
       v8::Local<v8::Name> property,
       const v8::PropertyCallbackInfo<v8::Integer>& info);

--- a/src/node_webstorage.cc
+++ b/src/node_webstorage.cc
@@ -598,7 +598,7 @@ static Intercepted StorageGetter(Local<Name> property,
 
 static Intercepted StorageSetter(Local<Name> property,
                                  Local<Value> value,
-                                 const PropertyCallbackInfo<void>& info) {
+                                 const PropertyCallbackInfo<Boolean>& info) {
   Storage* storage;
   ASSIGN_OR_RETURN_UNWRAP(&storage, info.HolderV2(), Intercepted::kNo);
 
@@ -648,7 +648,7 @@ static void StorageEnumerator(const PropertyCallbackInfo<Array>& info) {
 
 static Intercepted StorageDefiner(Local<Name> property,
                                   const PropertyDescriptor& desc,
-                                  const PropertyCallbackInfo<void>& info) {
+                                  const PropertyCallbackInfo<Boolean>& info) {
   Storage* storage;
   ASSIGN_OR_RETURN_UNWRAP(&storage, info.HolderV2(), Intercepted::kNo);
 
@@ -668,7 +668,7 @@ static Intercepted IndexedGetter(uint32_t index,
 
 static Intercepted IndexedSetter(uint32_t index,
                                  Local<Value> value,
-                                 const PropertyCallbackInfo<void>& info) {
+                                 const PropertyCallbackInfo<Boolean>& info) {
   Environment* env = Environment::GetCurrent(info);
   Local<Name> name = Uint32ToString(env->context(), index);
   return StorageSetter(name, value, info);
@@ -690,7 +690,7 @@ static Intercepted IndexedDeleter(uint32_t index,
 
 static Intercepted IndexedDefiner(uint32_t index,
                                   const PropertyDescriptor& desc,
-                                  const PropertyCallbackInfo<void>& info) {
+                                  const PropertyCallbackInfo<Boolean>& info) {
   Environment* env = Environment::GetCurrent(info);
   Local<Name> name = Uint32ToString(env->context(), index);
   return StorageDefiner(name, desc, info);


### PR DESCRIPTION
... i.e. the ones that have v8::PropertyCallbackInfo<void> argument to the ones with v8::PropertyCallbackInfo<v8::Boolean> argument.

No functional changes.

