### PR TITLE
[v8] Propagate v8_cppgc_microtask_queue flag to common.gypi

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -87,6 +87,7 @@
     'v8_enable_v8_checks%': 0,
     'v8_use_perfetto': 0,
     'tsan%': 0,
+    'v8_cppgc_microtask_queue%': 0,
 
     ##### end V8 defaults #####
 
@@ -543,6 +544,9 @@
       }],
       ['tsan == 1', {
         'defines': ['V8_IS_TSAN',],
+      }],
+      ['v8_cppgc_microtask_queue == 1', {
+        'defines': ['V8_CPPGC_MICROTASK_QUEUE',],
       }],
       ['OS == "win"', {
         'defines': [


### PR DESCRIPTION
v8_cppgc_microtask_queue affects the public ABI of v8::MicrotaskQueue. When enabled, it alters the class hierarchy (inheriting from cppgc::GarbageCollected) and changes the return type of MicrotaskQueue::New().

This flag must be propagated to GYP to ensure that native addons built via node-gyp are compiled with the identical V8 memory layout and method signatures as the Node.js executable, preventing silent ABI breakages and segfaults.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
